### PR TITLE
Insert render events as fake function slice nodes

### DIFF
--- a/packages/parse-profile/src/trace/cpuprofile.ts
+++ b/packages/parse-profile/src/trace/cpuprofile.ts
@@ -1,5 +1,8 @@
 import { hierarchy, HierarchyNode } from 'd3-hierarchy';
 import {
+  addRenderNodes
+} from './renderEvents';
+import {
   FUNCTION_NAME,
   ICpuProfile,
   ICpuProfileNode,
@@ -70,6 +73,8 @@ export default class CpuProfile {
 
     // Make child iteration easier
     this.hierarchy.each(node => { if (node.children === undefined) node.children = []; });
+
+    addRenderNodes(this.hierarchy, events);
   }
 
   parent(node: ICpuProfileNode) {
@@ -328,9 +333,6 @@ function addDurationToNodes(
   stack: ICpuProfileNode[],
   delta: number,
 ) {
-  for (let i = 0; i < stack.length; i++) {
-    stack[i].total += delta;
-  }
   if (stack.length > 0) stack[stack.length - 1].self += delta;
 }
 

--- a/packages/parse-profile/src/trace/export.ts
+++ b/packages/parse-profile/src/trace/export.ts
@@ -9,7 +9,6 @@ export function exportHierarchy(
     filePath: string) {
 
     const newTraceData = JSON.parse(JSON.stringify(rawTraceData));
-    const events: ITraceEvent[] = newTraceData.traceEvents;
     hierarchy.each(node => {
         const completeEvent: ITraceEvent = {
             pid: trace.mainProcess!.id,
@@ -23,7 +22,7 @@ export function exportHierarchy(
             dur: node.data.max - node.data.min,
         };
 
-        events.push(completeEvent);
+        newTraceData.traceEvents.push(completeEvent);
     });
 
     const outputFilePath = filePath.endsWith('.json') ? filePath.slice(0, filePath.length - 5) : filePath;

--- a/packages/parse-profile/src/trace/renderEvents.ts
+++ b/packages/parse-profile/src/trace/renderEvents.ts
@@ -1,0 +1,158 @@
+import binsearch from 'array-binsearch';
+import { HierarchyNode } from 'd3-hierarchy';
+import {
+  ICpuProfileNode,
+  ITraceEvent,
+  TRACE_EVENT_PHASE,
+} from './trace_event';
+
+export function addRenderNodes(hierarchy: HierarchyNode<ICpuProfileNode>, events: ITraceEvent[]) {
+  events.forEach(event => {
+    if (!isRenderPhase(event)) return;
+    let found: HierarchyNode<ICpuProfileNode> | null = null;
+    // Search for the closest node which fully encloses the render event
+    hierarchy.eachBefore((node: HierarchyNode<ICpuProfileNode>) => {
+      if (nodeEnclosesEvent(node, event)) found = node;
+    });
+    if (found) insertRenderEvent(found, event);
+  });
+}
+
+function nodeEnclosesEvent(node: HierarchyNode<ICpuProfileNode>, event: ITraceEvent) {
+  return node.data.min !== -1 && node.data.max !== -1 &&
+         node.data.min < event.ts && event.ts + event.dur! < node.data.max;
+}
+
+function insertRenderEvent(enclosingNode: HierarchyNode<ICpuProfileNode>, event: ITraceEvent) {
+  const eventStart = event.ts;
+  const eventEnd = event.ts + event.dur!;
+
+  const renderNode = enclosingNode.copy();
+  renderNode.data = {
+    id: -1,
+    callFrame: {
+      functionName: event.name,
+      scriptId: -1,
+      url: '',
+      lineNumber: -1,
+      columnNumber: -1
+    },
+    children: [],
+    sampleCount: -1,
+    min: eventStart,
+    max: eventEnd,
+    total: 0,
+    self: 0
+  };
+
+  // Children who are fully to the left or right of the render event
+  const childrenForOriginal = enclosingNode.children!.filter(child => child.data.max < eventStart ||
+                                                             child.data.min > eventEnd);
+  // Children who are fully within the render event
+  const childrenForRenderNode = enclosingNode.children!.filter(child => child.data.min > eventStart &&
+                                                               child.data.max < eventEnd);
+  // Children who are split by the render event
+  const leftSplitChild = enclosingNode.children!.find(n => n.data.min < eventStart && n.data.max > eventStart);
+  const rightSplitChild = enclosingNode.children!.find(n => n.data.min < eventEnd && n.data.max > eventEnd);
+
+  // Fix parent/child links for all children other then split children
+  enclosingNode.children = childrenForOriginal;
+  renderNode.children = childrenForRenderNode;
+  childrenForRenderNode.forEach(child => child.parent = renderNode);
+
+  // fix node/render node parent/child link
+  renderNode.parent = enclosingNode;
+  insertChildInOrder(enclosingNode.children!, renderNode);
+
+  splitChild(enclosingNode, renderNode, leftSplitChild, eventStart);
+  splitChild(renderNode, enclosingNode, rightSplitChild, eventEnd);
+}
+
+function insertChildInOrder(children: Array<HierarchyNode<ICpuProfileNode>>, node: HierarchyNode<ICpuProfileNode>) {
+  let index = binsearch(children, node, (a, b) => a.data.min - b.data.min);
+  if (index < 0) {
+    /* tslint:disable:no-bitwise */
+    index = ~index;
+  } else {
+    // insert just after if ts order matched
+    index++;
+  }
+  children.splice(index, 0, node);
+}
+
+function splitChild(leftParent: HierarchyNode<ICpuProfileNode>,
+                    rightParent: HierarchyNode<ICpuProfileNode>,
+                    node: HierarchyNode<ICpuProfileNode> | undefined,
+                    splitTS: number) {
+  if (node === undefined) return {middleLeftTime: 0, middleRightTime: 0};
+
+  // Split node
+  const left = node;
+  const right = node.copy();
+  right.data = JSON.parse(JSON.stringify(node.data));
+  right.children = [];
+
+  left.data.max = splitTS;
+  right.data.min = splitTS;
+
+  // Add back in the child/parent links for the split node
+  left.parent = leftParent;
+  right.parent = rightParent;
+  insertChildInOrder(leftParent.children!, left);
+  insertChildInOrder(rightParent.children!, right);
+
+  // If no further decendents, you are done
+  if (node.children!.length === 0) {
+    left.data.self = left.data.max - left.data.min;
+    right.data.self = right.data.max - right.data.min;
+    return {middleLeftTime: left.data.self, middleRightTime: right.data.self};
+  }
+
+  // Reasign children correctly
+  const middleChild = node.children!.find(n => n.data.min < splitTS && n.data.max > splitTS);
+  const leftChildren = node.children!.filter(child => child.data.max < left.data.max);
+  const rightChildren = node.children!.filter(child => child.data.min > right.data.min);
+
+  left.children = leftChildren;
+  right.children = rightChildren;
+
+  // Start to sum self time of children
+  let leftChildrenTime = leftChildren.reduce((a, b) => a + b.data.self, 0);
+  let righChildrentTime = rightChildren.reduce((a, b) => a + b.data.self, 0);
+
+  // Split middle child and asign the resulting left/right node self times
+  const { middleLeftTime, middleRightTime } = splitChild(left, right, middleChild, splitTS);
+  leftChildrenTime += middleLeftTime;
+  righChildrentTime += middleRightTime;
+
+  left.data.self = left.data.max - left.data.min - leftChildrenTime;
+  right.data.self = right.data.max - right.data.min - righChildrentTime;
+
+  // Return the resulting left/right split times, so parents can determine their own self times
+  return {middleLeftTime: left.data.max - left.data.min, middleRightTime: right.data.max - right.data.min};
+}
+
+export function isRenderEnd(event: ITraceEvent) {
+  return event.ph === TRACE_EVENT_PHASE.NESTABLE_ASYNC_END &&
+         isRender(event.name);
+}
+
+export function isRenderStart(event: ITraceEvent) {
+  return event.ph === TRACE_EVENT_PHASE.NESTABLE_ASYNC_BEGIN &&
+         isRender(event.name);
+}
+
+function isRenderPhase(event: ITraceEvent) {
+  return event.ph === TRACE_EVENT_PHASE.COMPLETE &&
+         isRender(event.name);
+}
+
+export function isRenderNode(node: ICpuProfileNode) {
+  return isRender(node.callFrame.functionName);
+}
+
+function isRender(name: string) {
+  return name.endsWith('(Rendering: initial)') ||
+         name.endsWith('(Rendering: update)') ||
+         name.endsWith('(Rendering: outlet)');
+}

--- a/packages/parse-profile/src/trace/trace.ts
+++ b/packages/parse-profile/src/trace/trace.ts
@@ -2,6 +2,10 @@ import binsearch from 'array-binsearch';
 import Bounds from './bounds';
 import CpuProfile from './cpuprofile';
 import Process from './process';
+import {
+  isRenderEnd,
+  isRenderStart
+} from './renderEvents';
 import Thread from './thread';
 import {
   ARGS,
@@ -191,7 +195,7 @@ export default class Trace {
   }
 
   private addEvent(event: ITraceEvent) {
-    if (event.ph === TRACE_EVENT_PHASE.END) {
+    if (event.ph === TRACE_EVENT_PHASE.END || isRenderEnd(event)) {
       this.endEvent(event);
       return;
     }
@@ -209,7 +213,7 @@ export default class Trace {
       this.addMetadata(event);
       return;
     }
-    if (event.ph === TRACE_EVENT_PHASE.BEGIN) {
+    if (event.ph === TRACE_EVENT_PHASE.BEGIN || isRenderStart(event)) {
       this.stack.push(event);
     }
     this.bounds.addEvent(event);

--- a/packages/parse-profile/tests/cpu-profile-test.ts
+++ b/packages/parse-profile/tests/cpu-profile-test.ts
@@ -30,6 +30,7 @@ describe('CpuProfile', () => {
     const json = generator.end();
     const profile = new CpuProfile(json, generator.events, -1, -1);
 
+    // Flame chart style view of setup //
     // [root                     ]
     // [a1 (10)       ] [a2 (10) ]
     //         [b (20)]
@@ -43,7 +44,7 @@ describe('CpuProfile', () => {
     expect(a2.data.max).to.eq(45);
     expect(a2.data.self).to.eq(10);
 
-    const b = profile.hierarchy.children![0].children![0];
+    const b = a1.children![0];
     expect(b.data.min).to.eq(11);
     expect(b.data.max).to.eq(31);
     expect(b.data.self).to.eq(20);
@@ -80,6 +81,7 @@ describe('CpuProfile', () => {
     const json = generator.end();
     const profile = new CpuProfile(json, generator.events, -1, -1);
 
+    //            Flame chart style view of setup               //
     // [root                                                     ]
     // [a1 (10)       ] | (1) [Program 1] (1) | [a2 (10)         ]
     //     [GC (2)]                               [Program 2 (2)]
@@ -88,7 +90,7 @@ describe('CpuProfile', () => {
     expect(a1.data.max).to.eq(11);
     expect(a1.data.self).to.eq(8);
 
-    const GC = profile.hierarchy.children![0].children![0];
+    const GC = a1.children![0];
     expect(GC.data.min).to.eq(6);
     expect(GC.data.max).to.eq(8);
     expect(GC.data.self).to.eq(2);
@@ -98,9 +100,278 @@ describe('CpuProfile', () => {
     expect(a2.data.max).to.eq(24);
     expect(a2.data.self).to.eq(8);
 
-    const program2 = profile.hierarchy.children![1].children![0];
+    const program2 = a2.children![0];
     expect(program2.data.min).to.eq(19);
     expect(program2.data.max).to.eq(21);
     expect(program2.data.self).to.eq(2);
+  });
+
+  it('splits function slices by render event start/end', () => {
+    const generator = new ProfileGenerator();
+    const root = generator.start();
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    const a = generator.appendNode(root, {functionName: 'a'});
+    generator.tick(10);
+    generator.appendNode(a, {functionName: 'b'});
+    generator.tick(5);
+    generator.appendRenderEvent('<pillar@component:addond@addon::ember1> (Rendering: update)', 10);
+    generator.tick(5);
+    generator.appendNode(a, {functionName: 'c'});
+    generator.tick(10);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
+    const json = generator.end();
+    const profile = new CpuProfile(json, generator.events, -1, -1);
+
+    //     Flame chart style view of setup    //
+    // [root                                  ]
+    // [a 30                                  |
+    //            |render 10     |
+    //  10 | b' 5 | b'' 5 | c' 5 | c'' 5  |
+
+    // level 1 (root's children)
+    const a1 = profile.hierarchy.children![0];
+    expect(a1.data.min).to.eq(1);
+    expect(a1.data.max).to.eq(31);
+    expect(a1.data.self).to.eq(10);
+
+    // level 2 (a's children)
+    const b1 = a1.children![0];
+    expect(b1.data.min).to.eq(11);
+    expect(b1.data.max).to.eq(16);
+    expect(b1.data.self).to.eq(5);
+
+    const render = a1.children![1];
+    expect(render.data.min).to.eq(16);
+    expect(render.data.max).to.eq(26);
+    expect(render.data.self).to.eq(0);
+
+    const c2 = a1.children![2];
+    expect(c2.data.min).to.eq(26);
+    expect(c2.data.max).to.eq(31);
+    expect(c2.data.self).to.eq(5);
+
+    // level 3 (render's children)
+    const b2 = render.children![0];
+    expect(b2.data.min).to.eq(16);
+    expect(b2.data.max).to.eq(21);
+    expect(b2.data.self).to.eq(5);
+
+    const c1 = render.children![1];
+    expect(c1.data.min).to.eq(21);
+    expect(c1.data.max).to.eq(26);
+    expect(c1.data.self).to.eq(5);
+  });
+
+  it('splits function slices recursivly by render events', () => {
+    const generator = new ProfileGenerator();
+    const root = generator.start();
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    const a = generator.appendNode(root, {functionName: 'a'});
+    generator.tick(10);
+    const b = generator.appendNode(a, {functionName: 'b'});
+    generator.tick(3);
+    generator.appendNode(b, {functionName: 'c'});
+    generator.tick(2);
+    generator.appendRenderEvent('<pillar@component:addond@addon::ember1> (Rendering: update)', 10);
+    generator.tick(3);
+    generator.appendSample(b);
+    generator.tick(2);
+    generator.appendSample(a);
+    generator.tick(10);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
+
+    const json = generator.end();
+
+    const profile = new CpuProfile(json, generator.events, -1, -1);
+
+    //     Flame chart style view of setup    //
+    // [root                                  ]
+    // [a 30                                  |
+    //                 |render (10)        | 5
+    //   10 |   b' 5   |   b'' 5  |
+    //   13     | c' 2 | c'' 3 |
+
+    // level 1 (root's children)
+    const a1 = profile.hierarchy.children![0];
+    expect(a1.data.min).to.eq(1);
+    expect(a1.data.max).to.eq(31);
+    expect(a1.data.self).to.eq(20);
+
+    // level 2 (a's children)
+    const b1 = a1.children![0];
+    expect(b1.data.min).to.eq(11);
+    expect(b1.data.max).to.eq(16);
+    expect(b1.data.self).to.eq(3);
+
+    const render = a1.children![1];
+    expect(render.data.min).to.eq(16);
+    expect(render.data.max).to.eq(26);
+    expect(render.data.self).to.eq(0);
+
+    // level 3
+    const c1 = b1.children![0];
+    expect(c1.data.min).to.eq(14);
+    expect(c1.data.max).to.eq(16);
+    expect(c1.data.self).to.eq(2);
+
+    const b2 = render.children![0];
+    expect(b2.data.min).to.eq(16);
+    expect(b2.data.max).to.eq(21);
+    expect(b2.data.self).to.eq(2);
+
+    // level 4
+    const c2 = b2.children![0];
+    expect(c2.data.min).to.eq(16);
+    expect(c2.data.max).to.eq(19);
+    expect(c2.data.self).to.eq(3);
+  });
+
+  it('preserves non-split nodes correctly during render event insertion', () => {
+    const generator = new ProfileGenerator();
+    const root = generator.start();
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    const a = generator.appendNode(root, {functionName: 'a'});
+    generator.tick(5);
+    generator.appendNode(a, {functionName: 'b'});
+    generator.tick(5);
+    generator.appendSample(a);
+    generator.tick(2);
+    generator.appendRenderEvent('<pillar@component:addond@addon::ember1> (Rendering: update)', 10);
+    generator.tick(3);
+    generator.appendNode(a, {functionName: 'c'});
+    generator.tick(5);
+    generator.appendSample(a);
+    generator.tick(5);
+    generator.appendNode(a, {functionName: 'd'});
+    generator.tick(5);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
+
+    const json = generator.end();
+
+    const profile = new CpuProfile(json, generator.events, -1, -1);
+
+    //  Flame chart style view of setup //
+    // [root                            ]
+    // [a 30                            |
+    //       12    |render (10)|
+    //   5 | b 5 | 5  | c 5  | 5  | d 5 |
+
+    // level 1 (root's children)
+    const a1 = profile.hierarchy.children![0];
+    expect(a1.data.min).to.eq(1);
+    expect(a1.data.max).to.eq(31);
+    expect(a1.data.self).to.eq(15);
+
+    // level 2 (a's children)
+    const b1 = a1.children![0];
+    expect(b1.data.min).to.eq(6);
+    expect(b1.data.max).to.eq(11);
+    expect(b1.data.self).to.eq(5);
+
+    const render = a1.children![1];
+    expect(render.data.min).to.eq(13);
+    expect(render.data.max).to.eq(23);
+    expect(render.data.self).to.eq(0);
+
+    const d1 = a1.children![2];
+    expect(d1.data.min).to.eq(26);
+    expect(d1.data.max).to.eq(31);
+    expect(d1.data.self).to.eq(5);
+
+    // level 3
+    const c1 = render.children![0];
+    expect(c1.data.min).to.eq(16);
+    expect(c1.data.max).to.eq(21);
+    expect(c1.data.self).to.eq(5);
+  });
+
+  it('splits function slices by overlapping render events correctly', () => {
+    const generator = new ProfileGenerator();
+    const root = generator.start();
+
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, true);
+    generator.tick(1);
+    const a = generator.appendNode(root, {functionName: 'a'});
+    generator.tick(10);
+    const b = generator.appendNode(a, {functionName: 'b'});
+    generator.tick(3);
+    generator.appendNode(b, {functionName: 'c'});
+    generator.tick(2);
+    generator.appendRenderEvent('<pillar@component:addond@addon::ember1> (Rendering: update)', 12);
+    generator.tick(1);
+    generator.appendRenderEvent('<pillar@component:addond@addon::ember2> (Rendering: update)', 10);
+    generator.tick(3);
+    generator.appendSample(b);
+    generator.tick(2);
+    generator.appendSample(a);
+    generator.tick(9);
+    generator.appendEvent(TRACE_EVENT_NAME.V8_EXECUTE, false);
+
+    const json = generator.end();
+
+    const profile = new CpuProfile(json, generator.events, -1, -1);
+    //     Flame chart style view of setup   //
+    // [root                                  ]
+    // [a 30                                  |
+    //        14     |render' (12)            |
+    //        15     |     |render'' (10)     |
+    //   10 |  b' 5  |b'' 1| b''' 5   |  9
+    //   13     |c' 2|c'' 1| c''' 3|
+
+    // level 1 (root's children)
+    const a1 = profile.hierarchy.children![0];
+    expect(a1.data.min).to.eq(1);
+    expect(a1.data.max).to.eq(31);
+    expect(a1.data.self).to.eq(19);
+
+    // level 2 (a's children)
+    const b1 = a1.children![0];
+    expect(b1.data.min).to.eq(11);
+    expect(b1.data.max).to.eq(16);
+    expect(b1.data.self).to.eq(3);
+
+    const render = a1.children![1];
+    expect(render.data.min).to.eq(16);
+    expect(render.data.max).to.eq(28);
+    expect(render.data.self).to.eq(0);
+
+    // level 3
+    const c1 = b1.children![0];
+    expect(c1.data.min).to.eq(14);
+    expect(c1.data.max).to.eq(16);
+    expect(c1.data.self).to.eq(2);
+
+    const b2 = render.children![0];
+    expect(b2.data.min).to.eq(16);
+    expect(b2.data.max).to.eq(17);
+    expect(b2.data.self).to.eq(0);
+
+    const render2 = render.children![1];
+    expect(render2.data.min).to.eq(17);
+    expect(render2.data.max).to.eq(27);
+    expect(render2.data.self).to.eq(0);
+
+    // level 4
+    const c2 = b2.children![0];
+    expect(c2.data.min).to.eq(16);
+    expect(c2.data.max).to.eq(17);
+    expect(c2.data.self).to.eq(1);
+
+    const b3 = render2.children![0];
+    expect(b3.data.min).to.eq(17);
+    expect(b3.data.max).to.eq(22);
+    expect(b3.data.self).to.eq(2);
+
+    // level 5
+    const c3 = b3.children![0];
+    expect(c3.data.min).to.eq(17);
+    expect(c3.data.max).to.eq(20);
+    expect(c3.data.self).to.eq(3);
   });
 });

--- a/packages/parse-profile/tests/generators.ts
+++ b/packages/parse-profile/tests/generators.ts
@@ -112,6 +112,21 @@ export class ProfileGenerator {
     this.lastAppend = this.curTime;
   }
 
+  appendRenderEvent(name: string, duration: number) {
+    let event: ITraceEvent;
+    event = {
+      pid: -1,
+      tid: -1,
+      ts: this.curTime,
+      ph: TRACE_EVENT_PHASE.COMPLETE,
+      dur: duration,
+      cat: '',
+      name,
+      args: {},
+    };
+    this.events.push(event);
+  }
+
   appendEvent(name: TRACE_EVENT_NAME, isStart: boolean) {
     let event: ITraceEvent;
     if (name === TRACE_EVENT_NAME.V8_EXECUTE) {


### PR DESCRIPTION
**What it does**
This PR reads [ember-perf-timeline](https://github.com/ember-best-practices/ember-perf-timeline) component render events from the trace file if they are present and inserts them into the cpuprofile node hierarchy as dummy ICpuProfileNode's. The time aggregation algo has been adjusted to ignore them. These will be used in future PRs for more detailed time aggregations.

**How it does it**
I had originally thought I could just treat render event start/end points as fake samples and get them inserted in the same step as the profile expansion. However, to determine which node to place the event under, I had to know the end time of the node, and this isn't easily to know/pre-compute in a clean way when looking at single, un-expanded samples in sequence. I opted instead to insert render nodes after the profile expansion, and deal with all of the descendent splitting that it entailed. This had to benefit of keeping this logic out of the expiation algorithm to reduce complexity there.

**Shortcuts**
- For convenience I've chosen to treat render events as dummy cpuprofile objects. In a future PR I will start doing more complicated time aggregations using these nodes, and may then opt to make them their own node type.
- To start with I'm only processing (Rendering: initial/update/outlet) events. Once I start working with them more I will figure out which ones are the most useful, and will add/remove event types as needed (and maybe subclass them).
- I'm cloning the parent node to create the render node, but I'm not fixing some of the properties, like height and depth. For now it's fine, but in the future I may need to adjust this or find a better solution.
- I'm asserting (!) that the children array is defined in a lot of places. The type definition should probably just be changed to have an empty array as default rather than undefined.