### PR TITLE
Terminate function slices at the end of trace correctly

### DIFF
--- a/packages/parse-profile/src/trace/cpuprofile.ts
+++ b/packages/parse-profile/src/trace/cpuprofile.ts
@@ -261,6 +261,7 @@ function expandNodes(
     }
   }
 
+  terminateNodes(state.stack, state.lastSampleTS, state);
   return {expandedNodes, orig2ExpNodes};
 }
 


### PR DESCRIPTION
We normally terminate a function slice when we see a sample which doesn't contain it (or the current v8.execute event ends). We allow the user to specify an end point for the analysis, and sometimes that endpoint may occur when a function is actively running. In order to handle this, this PR will terminate any active function slices once we hit the endpoint.