### PR TITLE
Run aggregate on all render nodes

### DIFF
--- a/packages/parse-profile/src/cli/analyze.ts
+++ b/packages/parse-profile/src/cli/analyze.ts
@@ -14,6 +14,7 @@ import {
   addRemainingModules,
   computeMinMax,
   formatCategories,
+  getRenderingNodes,
   methodsFromCategories
 } from './utils';
 
@@ -47,6 +48,15 @@ export async function analyze(options: IAnalyze) {
   let categorized = categorizeAggregations(collapsed, categories);
 
   reporter(categorized);
+
+  const renderNodes = getRenderingNodes(hierarchy);
+  renderNodes.forEach(node => {
+    let renderAgg = aggregate(node, allMethods, archiveFile, modMatcher);
+    let renderCollapsed = collapseCallFrames(renderAgg);
+    let renderCategorized = categorizeAggregations(renderCollapsed, categories);
+    console.log(`Render Node:${node.data.callFrame.functionName}`); // tslint:disable-line  no-console
+    reporter(renderCategorized);
+  });
 }
 
 function getCPUProfile(trace: Trace, event?: string) {

--- a/packages/parse-profile/src/cli/reporter.ts
+++ b/packages/parse-profile/src/cli/reporter.ts
@@ -4,15 +4,30 @@ import { Categorized } from './aggregator';
 import { Table } from './table';
 import { AUTO_ADD_CAT } from './utils';
 
-export function report(categorized: Categorized) {
-  let table = new Table();
+function findTotalAttrTime(categorized: Categorized) {
   let totalAggregatedTime = 0;
-
   Object.keys(categorized).forEach(category => {
     categorized[category].forEach(result => {
       totalAggregatedTime += result.attributed;
     });
   });
+  return totalAggregatedTime;
+}
+
+function filterZeroTotalCats(categorized: Categorized) {
+  return Object.keys(categorized).reduce((map, category) => {
+    const filtered = categorized[category].filter(result => {
+      return result.total > 0;
+    });
+    if (filtered.length > 0) map[category] = filtered;
+    return map;
+  }, {} as Categorized);
+}
+
+export function report(categorized: Categorized) {
+  let table = new Table();
+  let totalAggregatedTime = findTotalAttrTime(categorized);
+  categorized = filterZeroTotalCats(categorized);
 
   Object.keys(categorized).forEach(category => {
     let row = table.addRow();

--- a/packages/parse-profile/src/cli/utils.ts
+++ b/packages/parse-profile/src/cli/utils.ts
@@ -1,8 +1,10 @@
 // tslint:disable:no-console
 
+import { HierarchyNode } from 'd3-hierarchy';
 import * as fs from 'fs';
 import * as path from 'path';
-import { Trace } from '../trace';
+import { ICpuProfileNode, Trace } from '../trace';
+import { isRenderNode } from '../trace/renderEvents';
 import { ModuleMatcher } from './module_matcher';
 import { Categories, Locator } from './utils';
 
@@ -18,6 +20,14 @@ export interface Locator {
 }
 
 export const AUTO_ADD_CAT = 'Auto Added Module Paths';
+
+export function getRenderingNodes(root: HierarchyNode<ICpuProfileNode>) {
+  const renderNodes: Array<HierarchyNode<ICpuProfileNode>> = [];
+  root.each((node: HierarchyNode<ICpuProfileNode>) => {
+    if (isRenderNode(node)) renderNodes.push(node);
+  });
+  return renderNodes;
+}
 
 export function filterObjectByKeys(obj: any, keyArray: string[]) {
   let _obj = Object.assign({}, obj);

--- a/packages/parse-profile/src/trace/export.ts
+++ b/packages/parse-profile/src/trace/export.ts
@@ -15,7 +15,6 @@ export function exportHierarchy(
         const completeEvent: ITraceEvent = {
             pid: trace.mainProcess!.id,
             tid: trace.mainProcess!.mainThread!.id,
-            tdur: node.data.max - node.data.min,
             ts: node.data.min,
             ph: TRACE_EVENT_PHASE.COMPLETE,
             cat: 'blink.user_timing',

--- a/packages/parse-profile/src/trace/renderEvents.ts
+++ b/packages/parse-profile/src/trace/renderEvents.ts
@@ -150,8 +150,8 @@ function isRenderPhase(event: ITraceEvent) {
          isRender(event.name);
 }
 
-export function isRenderNode(node: ICpuProfileNode) {
-  return isRender(node.callFrame.functionName);
+export function isRenderNode(node: HierarchyNode<ICpuProfileNode>) {
+  return isRender(node.data.callFrame.functionName);
 }
 
 function isRender(name: string) {


### PR DESCRIPTION
During cmd line output phase, iterate over every render node and aggregate modules for each. This gives you one aggregation for the overall trace, and one aggregation with each render node as the root. Piping this output into a file is currently a poor-man's way of doing this analysis for any specific render node. In future PRs I will design both a more programatic way to ingesting the results (json output) as well as a more interactive UI that can be used to do this selectively on the fly.