### PR TITLE
Gets rid of null assertion operator use

### DIFF
--- a/packages/parse-profile/src/trace/cpuprofile.ts
+++ b/packages/parse-profile/src/trace/cpuprofile.ts
@@ -92,6 +92,11 @@ export default class CpuProfile {
   }
 }
 
+export function getChildren(node: HierarchyNode<ICpuProfileNode>) {
+  if (node.children === undefined) throw new Error('Node had undefined children');
+  return node.children;
+}
+
 function expandAndFix(
   samples: ISample[],
   profile: ICpuProfile,

--- a/packages/parse-profile/src/trace/renderEvents.ts
+++ b/packages/parse-profile/src/trace/renderEvents.ts
@@ -46,15 +46,16 @@ function insertRenderEvent(enclosingNode: HierarchyNode<ICpuProfileNode>, event:
     self: 0
   };
 
+  const children = getChildren(enclosingNode);
   // Children who are fully to the left or right of the render event
-  const childrenForOriginal = getChildren(enclosingNode).filter(child => child.data.max < eventStart ||
+  const childrenForOriginal = children.filter(child => child.data.max < eventStart ||
                                                              child.data.min > eventEnd);
   // Children who are fully within the render event
-  const childrenForRenderNode = getChildren(enclosingNode).filter(child => child.data.min > eventStart &&
+  const childrenForRenderNode = children.filter(child => child.data.min > eventStart &&
                                                                child.data.max < eventEnd);
   // Children who are split by the render event
-  const leftSplitChild = getChildren(enclosingNode).find(n => n.data.min < eventStart && n.data.max > eventStart);
-  const rightSplitChild = getChildren(enclosingNode).find(n => n.data.min < eventEnd && n.data.max > eventEnd);
+  const leftSplitChild = children.find(n => n.data.min < eventStart && n.data.max > eventStart);
+  const rightSplitChild = children.find(n => n.data.min < eventEnd && n.data.max > eventEnd);
 
   // Fix parent/child links for all children other then split children
   enclosingNode.children = childrenForOriginal;
@@ -63,7 +64,7 @@ function insertRenderEvent(enclosingNode: HierarchyNode<ICpuProfileNode>, event:
 
   // fix node/render node parent/child link
   renderNode.parent = enclosingNode;
-  insertChildInOrder(getChildren(enclosingNode), renderNode);
+  insertChildInOrder(enclosingNode.children, renderNode);
 
   splitChild(enclosingNode, renderNode, leftSplitChild, eventStart);
   splitChild(renderNode, enclosingNode, rightSplitChild, eventEnd);
@@ -102,17 +103,18 @@ function splitChild(leftParent: HierarchyNode<ICpuProfileNode>,
   insertChildInOrder(getChildren(leftParent), left);
   insertChildInOrder(getChildren(rightParent), right);
 
+  const children = getChildren(node);
   // If no further decendents, you are done
-  if (getChildren(node).length === 0) {
+  if (children.length === 0) {
     left.data.self = left.data.max - left.data.min;
     right.data.self = right.data.max - right.data.min;
     return {middleLeftTime: left.data.self, middleRightTime: right.data.self};
   }
 
   // Reasign children correctly
-  const middleChild = getChildren(node)!.find(n => n.data.min < splitTS && n.data.max > splitTS);
-  const leftChildren = getChildren(node)!.filter(child => child.data.max < left.data.max);
-  const rightChildren = getChildren(node)!.filter(child => child.data.min > right.data.min);
+  const middleChild = children.find(n => n.data.min < splitTS && n.data.max > splitTS);
+  const leftChildren = children.filter(child => child.data.max < left.data.max);
+  const rightChildren = children.filter(child => child.data.min > right.data.min);
 
   left.children = leftChildren;
   right.children = rightChildren;


### PR DESCRIPTION
This gets rid of the null assertion operator use in the code base, which was used to asset that the hierarchy node's .children array was defined. When I create the hierarchy nodes I ensure that they have at least an empty array as children, but the D3 hierarchy type allows them to be undefined. I played around trying to extend the hierarchy node type and use that, but it had other annoying issues. In the end I just wrote an accessor function to the node's children array which throws an error if it's not defined.