### PR TITLE
Emulate Mobile Device

### DIFF
--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -16,6 +16,7 @@ import {
   runtimeStats,
   json,
   debug,
+  emulateDevice
 } from '../helpers/flags';
 import { fidelityLookup } from '../helpers/default-flag-args';
 import { logCompareResults } from '../helpers/log-compare-results';
@@ -37,6 +38,7 @@ export default class Compare extends Command {
     runtimeStats: runtimeStats({ required: true }),
     json,
     debug,
+    emulateDevice: emulateDevice({ required: false })
   };
 
   public async run() {
@@ -51,6 +53,7 @@ export default class Compare extends Command {
       runtimeStats,
       json,
       debug,
+      emulateDevice
     } = flags;
     let { markers, fidelity, network } = flags;
 
@@ -76,7 +79,7 @@ export default class Compare extends Command {
 
     const delay = 100;
     const browser = {
-      additionalArguments: browserArgs,
+      additionalArguments: browserArgs
     };
 
     // todo: leverage har-remix
@@ -86,6 +89,7 @@ export default class Compare extends Command {
         browser,
         cpuThrottleRate,
         delay,
+        emulateDeviceSettings: emulateDevice,
         markers,
         networkConditions: network,
         name: 'control',
@@ -96,6 +100,7 @@ export default class Compare extends Command {
       experiment: new InitialRenderBenchmark({
         browser,
         delay,
+        emulateDeviceSettings: emulateDevice,
         markers,
         networkConditions: network,
         name: 'experiment',

--- a/packages/cli/src/helpers/default-flag-args.ts
+++ b/packages/cli/src/helpers/default-flag-args.ts
@@ -57,5 +57,6 @@ export const defaultFlagArgs: ITBConfig = {
   tracingLocationSearch: '?tracing',
   network: 'none',
   runtimeStats: 'false',
+  emulateDevice: null,
   routes: ['/'],
 };

--- a/packages/cli/src/helpers/flags.ts
+++ b/packages/cli/src/helpers/flags.ts
@@ -2,8 +2,9 @@ import { flags } from '@oclif/command';
 import { networkConditions } from 'tracerbench';
 import { Network } from 'chrome-debugging-client/dist/protocol/tot';
 import { defaultFlagArgs, fidelityLookup } from './default-flag-args';
-import { parseMarkers } from './utils';
 import { getConfigDefault } from './tb-config';
+import { parseMarkers } from './utils';
+import deviceSettings, { EmulateDeviceSetting } from './simulate-device-options';
 
 /*
 ! oclif flags.build#parse will only execute when the flag:string is passed directly
@@ -193,4 +194,18 @@ export const marks = flags.build({
 export const urlOrFrame = flags.build({
   default: () => getConfigDefault('urlOrFrame'),
   description: 'URL or Frame',
+});
+
+export const emulateDevice = flags.build({
+  char: 'e',
+  default: () => getConfigDefault('emulateDevice', defaultFlagArgs.emulateDevice),
+  description: 'Simulate a device\'s screen size.',
+  options: deviceSettings.map(setting => `${setting.typeable}`),
+  parse: (s: string): EmulateDeviceSetting | undefined => {
+    for(const option of deviceSettings) {
+      if (s === option.typeable) {
+        return option;
+      }
+    }
+  },
 });

--- a/packages/cli/src/helpers/simulate-device-options.ts
+++ b/packages/cli/src/helpers/simulate-device-options.ts
@@ -1,0 +1,27 @@
+import { Emulation } from 'chrome-debugging-client/dist/protocol/tot';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { convertToTypable } from './utils';
+
+export interface EmulateDeviceSetting extends Emulation.SetDeviceMetricsOverrideParameters {
+  name: string;
+  typeable: string;
+  userAgent: string;
+}
+
+const deviceSettingsRaw = readFileSync(resolve(__dirname, '../static/simulate-device-options.json')).toString();
+const deviceSettingsJson = JSON.parse(deviceSettingsRaw);
+
+const deviceSettings: EmulateDeviceSetting[] = deviceSettingsJson.map((item: any) => {
+  return {
+    width: item.device.screen.horizontal.width,
+    height: item.device.screen.horizontal.height,
+    deviceScaleFactor: item.device.screen['device-pixel-ratio'] || 0,
+    mobile: item.device.capabilities.indexOf('mobile') > -1,
+    userAgent: item.device['user-agent'],
+    typeable: convertToTypable(item.device.title),
+    name: item.device.title
+  };
+});
+
+export default deviceSettings;

--- a/packages/cli/src/helpers/tb-config.ts
+++ b/packages/cli/src/helpers/tb-config.ts
@@ -35,6 +35,7 @@ export interface ITBConfig {
   iterations?: number | string;
   tracingLocationSearch?: string;
   runtimeStats?: 'true' | 'false';
+  emulateDevice?: string | null;
 }
 
 type ITBConfigKeys = keyof ITBConfig;

--- a/packages/cli/src/helpers/utils.ts
+++ b/packages/cli/src/helpers/utils.ts
@@ -126,3 +126,14 @@ export function fillArray(
   }
   return a;
 }
+/**
+ * "name" is expected to be a titlecased string. We want something the user can type easily so the passed string
+ * is converted into lowercased words dasherized. Any extra "/" will also be removed.
+ *
+ * @param str - String to be converted to dasherized case
+ */
+export function convertToTypable (name: string): string {
+  const split = name.split(' ');
+  const lowercasedWords = split.map(word => word.toLowerCase().replace(/\//g, ''));
+  return lowercasedWords.join('-');
+};

--- a/packages/cli/src/static/simulate-device-options.json
+++ b/packages/cli/src/static/simulate-device-options.json
@@ -1,0 +1,1646 @@
+[
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "iPhone 4",
+      "screen": {
+        "horizontal": {
+          "width": 480,
+          "height": 320
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 320,
+          "height": 480
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "order": 30,
+    "device": {
+      "show-by-default": true,
+      "title": "iPhone 5/SE",
+      "screen": {
+        "horizontal": {
+          "outline": {
+            "image": "@url(iPhone5-landscape.svg)",
+            "insets": {
+              "left": 115,
+              "top": 25,
+              "right": 115,
+              "bottom": 28
+            }
+          },
+          "width": 568,
+          "height": 320
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "outline": {
+            "image": "@url(iPhone5-portrait.svg)",
+            "insets": {
+              "left": 29,
+              "top": 105,
+              "right": 25,
+              "bottom": 111
+            }
+          },
+          "width": 320,
+          "height": 568
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "order": 31,
+    "device": {
+      "show-by-default": true,
+      "title": "iPhone 6/7/8",
+      "screen": {
+        "horizontal": {
+          "outline": {
+            "image": "@url(iPhone6-landscape.svg)",
+            "insets": {
+              "left": 106,
+              "top": 28,
+              "right": 106,
+              "bottom": 28
+            }
+          },
+          "width": 667,
+          "height": 375
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "outline": {
+            "image": "@url(iPhone6-portrait.svg)",
+            "insets": {
+              "left": 28,
+              "top": 105,
+              "right": 28,
+              "bottom": 105
+            }
+          },
+          "width": 375,
+          "height": 667
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "order": 32,
+    "device": {
+      "show-by-default": true,
+      "title": "iPhone 6/7/8 Plus",
+      "screen": {
+        "horizontal": {
+          "outline": {
+            "image": "@url(iPhone6Plus-landscape.svg)",
+            "insets": {
+              "left": 109,
+              "top": 29,
+              "right": 109,
+              "bottom": 27
+            }
+          },
+          "width": 736,
+          "height": 414
+        },
+        "device-pixel-ratio": 3,
+        "vertical": {
+          "outline": {
+            "image": "@url(iPhone6Plus-portrait.svg)",
+            "insets": {
+              "left": 26,
+              "top": 107,
+              "right": 30,
+              "bottom": 111
+            }
+          },
+          "width": 414,
+          "height": 736
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "order": 33,
+    "device": {
+      "show-by-default": true,
+      "title": "iPhone X",
+      "screen": {
+        "horizontal": {
+          "width": 812,
+          "height": 375
+        },
+        "device-pixel-ratio": 3,
+        "vertical": {
+          "width": 375,
+          "height": 812
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "BlackBerry Z30",
+      "screen": {
+        "horizontal": {
+          "width": 640,
+          "height": 360
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 360,
+          "height": 640
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Nexus 4",
+      "screen": {
+        "horizontal": {
+          "width": 640,
+          "height": 384
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 384,
+          "height": 640
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "title": "Nexus 5",
+      "type": "phone",
+      "user-agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "show-by-default": false,
+      "screen": {
+        "device-pixel-ratio": 3,
+        "vertical": {
+          "width": 360,
+          "height": 640
+        },
+        "horizontal": {
+          "width": 640,
+          "height": 360
+        }
+      },
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 25,
+            "right": 0,
+            "bottom": 48
+          },
+          "image": "@url(google-nexus-5-vertical-default-1x.png) 1x, @url(google-nexus-5-vertical-default-2x.png) 2x"
+        },
+        {
+          "title": "navigation bar",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 80,
+            "right": 0,
+            "bottom": 48
+          },
+          "image": "@url(google-nexus-5-vertical-navigation-1x.png) 1x, @url(google-nexus-5-vertical-navigation-2x.png) 2x"
+        },
+        {
+          "title": "keyboard",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 80,
+            "right": 0,
+            "bottom": 312
+          },
+          "image": "@url(google-nexus-5-vertical-keyboard-1x.png) 1x, @url(google-nexus-5-vertical-keyboard-2x.png) 2x"
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 25,
+            "right": 42,
+            "bottom": 0
+          },
+          "image": "@url(google-nexus-5-horizontal-default-1x.png) 1x, @url(google-nexus-5-horizontal-default-2x.png) 2x"
+        },
+        {
+          "title": "navigation bar",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 80,
+            "right": 42,
+            "bottom": 0
+          },
+          "image": "@url(google-nexus-5-horizontal-navigation-1x.png) 1x, @url(google-nexus-5-horizontal-navigation-2x.png) 2x"
+        },
+        {
+          "title": "keyboard",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 80,
+            "right": 42,
+            "bottom": 202
+          },
+          "image": "@url(google-nexus-5-horizontal-keyboard-1x.png) 1x, @url(google-nexus-5-horizontal-keyboard-2x.png) 2x"
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "title": "Nexus 5X",
+      "type": "phone",
+      "user-agent": "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "show-by-default": false,
+      "screen": {
+        "device-pixel-ratio": 2.625,
+        "vertical": {
+          "outline": {
+            "image": "@url(Nexus5X-portrait.svg)",
+            "insets": {
+              "left": 18,
+              "top": 88,
+              "right": 22,
+              "bottom": 98
+            }
+          },
+          "width": 412,
+          "height": 732
+        },
+        "horizontal": {
+          "outline": {
+            "image": "@url(Nexus5X-landscape.svg)",
+            "insets": {
+              "left": 88,
+              "top": 21,
+              "right": 98,
+              "bottom": 19
+            }
+          },
+          "width": 732,
+          "height": 412
+        }
+      },
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 24,
+            "right": 0,
+            "bottom": 48
+          },
+          "image": "@url(google-nexus-5x-vertical-default-1x.png) 1x, @url(google-nexus-5x-vertical-default-2x.png) 2x"
+        },
+        {
+          "title": "navigation bar",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 80,
+            "right": 0,
+            "bottom": 48
+          },
+          "image": "@url(google-nexus-5x-vertical-navigation-1x.png) 1x, @url(google-nexus-5x-vertical-navigation-2x.png) 2x"
+        },
+        {
+          "title": "keyboard",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 80,
+            "right": 0,
+            "bottom": 342
+          },
+          "image": "@url(google-nexus-5x-vertical-keyboard-1x.png) 1x, @url(google-nexus-5x-vertical-keyboard-2x.png) 2x"
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 24,
+            "right": 48,
+            "bottom": 0
+          },
+          "image": "@url(google-nexus-5x-horizontal-default-1x.png) 1x, @url(google-nexus-5x-horizontal-default-2x.png) 2x"
+        },
+        {
+          "title": "navigation bar",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 80,
+            "right": 48,
+            "bottom": 0
+          },
+          "image": "@url(google-nexus-5x-horizontal-navigation-1x.png) 1x, @url(google-nexus-5x-horizontal-navigation-2x.png) 2x"
+        },
+        {
+          "title": "keyboard",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 80,
+            "right": 48,
+            "bottom": 222
+          },
+          "image": "@url(google-nexus-5x-horizontal-keyboard-1x.png) 1x, @url(google-nexus-5x-horizontal-keyboard-2x.png) 2x"
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Nexus 6",
+      "screen": {
+        "horizontal": {
+          "width": 732,
+          "height": 412
+        },
+        "device-pixel-ratio": 3.5,
+        "vertical": {
+          "width": 412,
+          "height": 732
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Nexus 6P",
+      "screen": {
+        "horizontal": {
+          "outline": {
+            "image": "@url(Nexus6P-landscape.svg)",
+            "insets": {
+              "left": 94,
+              "top": 17,
+              "right": 88,
+              "bottom": 17
+            }
+          },
+          "width": 732,
+          "height": 412
+        },
+        "device-pixel-ratio": 3.5,
+        "vertical": {
+          "outline": {
+            "image": "@url(Nexus6P-portrait.svg)",
+            "insets": {
+              "left": 16,
+              "top": 94,
+              "right": 16,
+              "bottom": 88
+            }
+          },
+          "width": 412,
+          "height": 732
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "order": 20,
+    "device": {
+      "show-by-default": true,
+      "title": "Pixel 2",
+      "screen": {
+        "horizontal": {
+          "width": 731,
+          "height": 411
+        },
+        "device-pixel-ratio": 2.625,
+        "vertical": {
+          "width": 411,
+          "height": 731
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "order": 21,
+    "device": {
+      "show-by-default": true,
+      "title": "Pixel 2 XL",
+      "screen": {
+        "horizontal": {
+          "width": 823,
+          "height": 411
+        },
+        "device-pixel-ratio": 3.5,
+        "vertical": {
+          "width": 411,
+          "height": 823
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "LG Optimus L70",
+      "screen": {
+        "horizontal": {
+          "width": 640,
+          "height": 384
+        },
+        "device-pixel-ratio": 1.25,
+        "vertical": {
+          "width": 384,
+          "height": 640
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/%s Mobile Safari/537.36",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Nokia N9",
+      "screen": {
+        "horizontal": {
+          "width": 854,
+          "height": 480
+        },
+        "device-pixel-ratio": 1,
+        "vertical": {
+          "width": 480,
+          "height": 854
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Nokia Lumia 520",
+      "screen": {
+        "horizontal": {
+          "width": 533,
+          "height": 320
+        },
+        "device-pixel-ratio": 1.5,
+        "vertical": {
+          "width": 320,
+          "height": 533
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Microsoft Lumia 550",
+      "screen": {
+        "horizontal": {
+          "width": 640,
+          "height": 360
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 640,
+          "height": 360
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Microsoft Lumia 950",
+      "screen": {
+        "horizontal": {
+          "width": 640,
+          "height": 360
+        },
+        "device-pixel-ratio": 4,
+        "vertical": {
+          "width": 360,
+          "height": 640
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Galaxy S III",
+      "screen": {
+        "horizontal": {
+          "width": 640,
+          "height": 360
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 360,
+          "height": 640
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "order": 10,
+    "device": {
+      "show-by-default": true,
+      "title": "Galaxy S5",
+      "screen": {
+        "horizontal": {
+          "width": 640,
+          "height": 360
+        },
+        "device-pixel-ratio": 3,
+        "vertical": {
+          "width": 360,
+          "height": 640
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Kindle Fire HDX",
+      "screen": {
+        "horizontal": {
+          "width": 1280,
+          "height": 800
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 800,
+          "height": 1280
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true",
+      "type": "tablet",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "iPad Mini",
+      "screen": {
+        "horizontal": {
+          "width": 1024,
+          "height": 768
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 768,
+          "height": 1024
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1",
+      "type": "tablet",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "order": 40,
+    "device": {
+      "show-by-default": true,
+      "title": "iPad",
+      "screen": {
+        "horizontal": {
+          "outline": {
+            "image": "@url(iPad-landscape.svg)",
+            "insets": {
+              "left": 112,
+              "top": 56,
+              "right": 116,
+              "bottom": 52
+            }
+          },
+          "width": 1024,
+          "height": 768
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "outline": {
+            "image": "@url(iPad-portrait.svg)",
+            "insets": {
+              "left": 52,
+              "top": 114,
+              "right": 55,
+              "bottom": 114
+            }
+          },
+          "width": 768,
+          "height": 1024
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1",
+      "type": "tablet",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "order": 41,
+    "device": {
+      "show-by-default": true,
+      "title": "iPad Pro",
+      "screen": {
+        "horizontal": {
+          "width": 1366,
+          "height": 1024
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 1024,
+          "height": 1366
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1",
+      "type": "tablet",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Blackberry PlayBook",
+      "screen": {
+        "horizontal": {
+          "width": 1024,
+          "height": 600
+        },
+        "device-pixel-ratio": 1,
+        "vertical": {
+          "width": 600,
+          "height": 1024
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+",
+      "type": "tablet",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Nexus 10",
+      "screen": {
+        "horizontal": {
+          "width": 1280,
+          "height": 800
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 800,
+          "height": 1280
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36",
+      "type": "tablet",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Nexus 7",
+      "screen": {
+        "horizontal": {
+          "width": 960,
+          "height": 600
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 600,
+          "height": 960
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36",
+      "type": "tablet",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Galaxy Note 3",
+      "screen": {
+        "horizontal": {
+          "width": 640,
+          "height": 360
+        },
+        "device-pixel-ratio": 3,
+        "vertical": {
+          "width": 360,
+          "height": 640
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Galaxy Note II",
+      "screen": {
+        "horizontal": {
+          "width": 640,
+          "height": 360
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 360,
+          "height": 640
+        }
+      },
+      "capabilities": [
+        "touch",
+        "mobile"
+      ],
+      "user-agent": "Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+      "type": "phone",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "vertical",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        },
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Laptop with touch",
+      "screen": {
+        "horizontal": {
+          "width": 1280,
+          "height": 950
+        },
+        "device-pixel-ratio": 1,
+        "vertical": {
+          "width": 950,
+          "height": 1280
+        }
+      },
+      "capabilities": [
+        "touch"
+      ],
+      "user-agent": "",
+      "type": "notebook",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Laptop with HiDPI screen",
+      "screen": {
+        "horizontal": {
+          "width": 1440,
+          "height": 900
+        },
+        "device-pixel-ratio": 2,
+        "vertical": {
+          "width": 900,
+          "height": 1440
+        }
+      },
+      "capabilities": [],
+      "user-agent": "",
+      "type": "notebook",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "emulated-device",
+    "device": {
+      "show-by-default": false,
+      "title": "Laptop with MDPI screen",
+      "screen": {
+        "horizontal": {
+          "width": 1280,
+          "height": 800
+        },
+        "device-pixel-ratio": 1,
+        "vertical": {
+          "width": 800,
+          "height": 1280
+        }
+      },
+      "capabilities": [],
+      "user-agent": "",
+      "type": "notebook",
+      "modes": [
+        {
+          "title": "default",
+          "orientation": "horizontal",
+          "insets": {
+            "left": 0,
+            "top": 0,
+            "right": 0,
+            "bottom": 0
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -14,9 +14,13 @@
 
     "moduleResolution": "node",
     "module": "commonjs",
+    "resolveJsonModule": true,
     "target": "es2017",
     "outDir": "./dist"
   },
+  "include": [
+    "src"
+  ],
   "exclude": [
     "node_modules",
     "test"

--- a/packages/tracerbench/src/benchmarks/initial-render.ts
+++ b/packages/tracerbench/src/benchmarks/initial-render.ts
@@ -1,4 +1,4 @@
-import { Network } from 'chrome-debugging-client/dist/protocol/tot';
+import { Emulation, Network } from 'chrome-debugging-client/dist/protocol/tot';
 import * as fs from 'fs';
 import { Benchmark, IBenchmarkMeta, IBenchmarkParams } from '../benchmark';
 import { ITab } from '../tab';
@@ -52,6 +52,11 @@ export interface IInitialRenderBenchmarkParams extends IBenchmarkParams {
    * Save trace for each iteration, useful for debugging outliers in data.
    */
   saveTraces?: (iteration: number) => string;
+
+  /**
+   * Settings to emulate a device.
+   */
+  emulateDeviceSettings?: Emulation.SetDeviceMetricsOverrideParameters & Emulation.SetUserAgentOverrideParameters;
 }
 
 /**
@@ -97,6 +102,11 @@ export class InitialRenderBenchmark extends Benchmark<IInitialRenderSamples> {
 
     if (this.params.networkConditions !== undefined) {
       await t.emulateNetworkConditions(this.params.networkConditions);
+    }
+
+    if (this.params.emulateDeviceSettings !== undefined) {
+      await t.emulateDevice(this.params.emulateDeviceSettings);
+      await t.setUserAgent(this.params.emulateDeviceSettings);
     }
 
     const tracing = await t.startTracing(categories);

--- a/packages/tracerbench/src/tab.ts
+++ b/packages/tracerbench/src/tab.ts
@@ -35,6 +35,12 @@ export interface ITab {
     conditions: Network.EmulateNetworkConditionsParameters
   ): Promise<void>;
   disableNetworkEmulation(): Promise<void>;
+
+  /** Configure tab to take on the device emulation settings */
+  emulateDevice(deviceSettings: Emulation.SetDeviceMetricsOverrideParameters): Promise<void>;
+
+  /** Cofigure tabe to send the specified user agent */
+  setUserAgent(userAgentSettings: Emulation.SetUserAgentOverrideParameters): Promise<void>;
 }
 
 export default function createTab(
@@ -232,5 +238,13 @@ class Tab implements ITab {
     await heapProfiler.enable();
     await heapProfiler.collectGarbage();
     await heapProfiler.disable();
+  }
+
+  public async emulateDevice(deviceSettings: Emulation.SetDeviceMetricsOverrideParameters): Promise<void> {
+    await this.emulation.setDeviceMetricsOverride(deviceSettings);
+  }
+
+  public async setUserAgent(userAgentSettings: Emulation.SetUserAgentOverrideParameters): Promise<void> {
+    await this.emulation.setUserAgentOverride(userAgentSettings);
   }
 }


### PR DESCRIPTION
This feature uses the this json from [ChromeDevTools](https://github.com/ChromeDevTools/devtools-frontend/blob/51d3d758c57dc51d1864b3003de1fdda82963623/front_end/emulated_devices/module.json) to form the options. Each object in the "extensions" array attribute of the json contains settings such as screen size dimensions, and user-agent, and an accompanying device name such as iPhone 4.

We convert the name into a user typeable string so that we can match up a setting with the string when it comes time to parse which option the user wanted.