### PR TITLE
Renaming tbResultsFile -> tbResultsFolder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp/
 *.tmp
 .nyc_output
 /packages/har/index.d.ts
+.idea/

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,6 +9,7 @@
 <!-- toc -->
 * [Usage](#usage)
 * [Optional Config](#optional-config)
+* [Example Travis-CI Integration](#example-travis-ci-integration)
 * [FAQ](#faq)
 * [Commands](#commands)
 <!-- tocstop -->
@@ -21,7 +22,7 @@ $ npm install -g tracerbench-cli
 $ tracerbench COMMAND
 running command...
 $ tracerbench (-v|--version|version)
-tracerbench-cli/2.0.0-beta.15 darwin-x64 node-v10.15.2
+tracerbench-cli/2.0.0-beta.15 darwin-x64 node-v10.15.3
 $ tracerbench --help [COMMAND]
 USAGE
   $ tracerbench COMMAND
@@ -223,7 +224,7 @@ OPTIONS
   --socksPorts=socksPorts
       Specify a socks proxy port as browser option for control and experiment
 
-  --tbResultsFile=tbResultsFile
+  --tbResultsFolder=tbResultsFolder
       (required) [default: ./tracerbench-results] The output filepath for all tracerbench results
 
   --tracingLocationSearch=tracingLocationSearch
@@ -239,11 +240,11 @@ USAGE
   $ tracerbench create-archive
 
 OPTIONS
-  --tbResultsFile=tbResultsFile  (required) [default: ./tracerbench-results] The output filepath for all tracerbench
-                                 results
+  --tbResultsFolder=tbResultsFolder  (required) [default: ./tracerbench-results] The output filepath for all tracerbench
+                                     results
 
-  --url=url                      (required) [default: http://localhost:8000/] URL to visit for create-archive, timings &
-                                 trace commands
+  --url=url                          (required) [default: http://localhost:8000/] URL to visit for create-archive,
+                                     timings & trace commands
 ```
 
 ## `tracerbench help [COMMAND]`
@@ -272,15 +273,15 @@ USAGE
   $ tracerbench marker-timings
 
 OPTIONS
-  --filter=filter                User timing marks start with
+  --filter=filter                    User timing marks start with
 
-  --tbResultsFile=tbResultsFile  (required) [default: ./tracerbench-results] The output filepath for all tracerbench
-                                 results
+  --tbResultsFolder=tbResultsFolder  (required) [default: ./tracerbench-results] The output filepath for all tracerbench
+                                     results
 
-  --traceFrame=traceFrame        Specify a trace insights frame
+  --traceFrame=traceFrame            Specify a trace insights frame
 
-  --url=url                      (required) [default: http://localhost:8000/] URL to visit for create-archive, timings &
-                                 trace commands
+  --url=url                          (required) [default: http://localhost:8000/] URL to visit for create-archive,
+                                     timings & trace commands
 ```
 
 ## `tracerbench trace`
@@ -310,7 +311,7 @@ OPTIONS
   --network=none | offline | dialup | 2g | edge | slow-3g | em-3g | dsl | 3g | fast-3g | 4g | cable | LTE | FIOS
       [default: none] Simulated network conditions.
 
-  --tbResultsFile=tbResultsFile
+  --tbResultsFolder=tbResultsFolder
       (required) [default: ./tracerbench-results] The output filepath for all tracerbench results
 
   --url=url

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -16,7 +16,7 @@ import {
   fidelity,
   markers,
   network,
-  tbResultsFile,
+  tbResultsFolder,
   tracingLocationSearch,
   runtimeStats,
   json,
@@ -36,7 +36,7 @@ export interface ICompareFlags {
   fidelity: number;
   markers: IMarker[];
   network: Network.EmulateNetworkConditionsParameters;
-  tbResultsFile: string;
+  tbResultsFolder: string;
   controlURL: string;
   experimentURL: string;
   tracingLocationSearch: string;
@@ -60,7 +60,7 @@ export default class Compare extends Command {
     fidelity: fidelity({ required: true }),
     markers: markers({ required: true }),
     network: network({ required: true }),
-    tbResultsFile: tbResultsFile({ required: true }),
+    tbResultsFolder: tbResultsFolder({ required: true }),
     controlURL: controlURL({ required: true }),
     experimentURL: experimentURL({ required: true }),
     tracingLocationSearch: tracingLocationSearch({ required: true }),
@@ -75,7 +75,7 @@ export default class Compare extends Command {
   public async run() {
     const { flags } = this.parse(Compare);
     const {
-      tbResultsFile,
+      tbResultsFolder,
       debug,
       fidelity,
       network,
@@ -127,8 +127,8 @@ export default class Compare extends Command {
     }
     // if the folder for the tracerbench results file
     // does not exist then create it
-    if (!fs.existsSync(tbResultsFile)) {
-      fs.mkdirSync(tbResultsFile);
+    if (!fs.existsSync(tbResultsFolder)) {
+      fs.mkdirSync(tbResultsFolder);
     }
 
     // config for the browsers
@@ -164,7 +164,7 @@ export default class Compare extends Command {
         networkConditions: flags.network,
         name: 'control',
         runtimeStats: flags.runtimeStats,
-        saveTraces: () => `${flags.tbResultsFile}/control.json`,
+        saveTraces: () => `${flags.tbResultsFolder}/control.json`,
         url: path.join(flags.controlURL + flags.tracingLocationSearch),
       }),
       experiment: new InitialRenderBenchmark({
@@ -176,7 +176,7 @@ export default class Compare extends Command {
         networkConditions: flags.network,
         name: 'experiment',
         runtimeStats: flags.runtimeStats,
-        saveTraces: () => `${flags.tbResultsFile}/experiment.json`,
+        saveTraces: () => `${flags.tbResultsFolder}/experiment.json`,
         url: path.join(flags.experimentURL + flags.tracingLocationSearch),
       }),
     };
@@ -194,12 +194,12 @@ export default class Compare extends Command {
         }
 
         fs.writeFileSync(
-          `${flags.tbResultsFile}/compare.json`,
+          `${flags.tbResultsFolder}/compare.json`,
           JSON.stringify(results, null, 2)
         );
 
         fs.writeFileSync(
-          `${flags.tbResultsFile}/compare-stat-results.json`,
+          `${flags.tbResultsFolder}/compare-stat-results.json`,
           JSON.stringify(logCompareResults(results, flags, this), null, 2)
         );
       })

--- a/packages/cli/src/commands/create-archive.ts
+++ b/packages/cli/src/commands/create-archive.ts
@@ -1,22 +1,22 @@
 import { Command } from '@oclif/command';
 import { harTrace } from 'tracerbench';
-import { tbResultsFile, url } from '../helpers/flags';
+import { tbResultsFolder, url } from '../helpers/flags';
 import * as path from 'path';
 
 export default class CreateArchive extends Command {
   public static description = 'Creates an automated HAR file from a URL.';
   public static flags = {
-    tbResultsFile: tbResultsFile({ required: true }),
+    tbResultsFolder: tbResultsFolder({ required: true }),
     url: url({ required: true }),
   };
 
   public async run() {
     const { flags } = this.parse(CreateArchive);
-    const { url, tbResultsFile } = flags;
-    const archiveOutput = path.join(tbResultsFile, 'trace.har');
-    const cookiesJSON = path.join(tbResultsFile, 'cookies.json');
+    const { url, tbResultsFolder } = flags;
+    const archiveOutput = path.join(tbResultsFolder, 'trace.har');
+    const cookiesJSON = path.join(tbResultsFolder, 'cookies.json');
 
-    await harTrace(url, tbResultsFile);
+    await harTrace(url, tbResultsFolder);
     return this.log(
       `HAR & cookies.json successfully generated from ${url} and available here: ${archiveOutput} and ${cookiesJSON}`
     );

--- a/packages/cli/src/commands/marker-timings.ts
+++ b/packages/cli/src/commands/marker-timings.ts
@@ -2,7 +2,7 @@ import { Command } from '@oclif/command';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { ITraceEvent } from 'tracerbench';
-import { filter, tbResultsFile, url, traceFrame } from '../helpers/flags';
+import { filter, tbResultsFolder, url, traceFrame } from '../helpers/flags';
 import {
   byTime,
   collect,
@@ -20,7 +20,7 @@ export default class MarkerTimings extends Command {
   public static description = 'Get list of all user-timings from trace';
 
   public static flags = {
-    tbResultsFile: tbResultsFile({ required: true }),
+    tbResultsFolder: tbResultsFolder({ required: true }),
     filter: filter(),
     url: url({ required: true }),
     traceFrame: traceFrame(),
@@ -28,10 +28,10 @@ export default class MarkerTimings extends Command {
 
   public async run() {
     const { flags } = this.parse(MarkerTimings);
-    const { tbResultsFile } = flags;
+    const { tbResultsFolder } = flags;
     const filter = collect(flags.filter, []);
     const traceFrame: any = flags.traceFrame ? flags.traceFrame : flags.url;
-    const traceJSON = path.join(tbResultsFile, 'trace.json');
+    const traceJSON = path.join(tbResultsFolder, 'trace.json');
 
     let frame: any = null;
     let startTime = -1;

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -9,7 +9,7 @@ import {
   ITraceEvent,
 } from 'tracerbench';
 import {
-  tbResultsFile,
+  tbResultsFolder,
   cpuThrottleRate,
   iterations,
   network,
@@ -29,7 +29,7 @@ export default class Trace extends Command {
   public static description = `Parses a CPU profile and aggregates time across heuristics. Can optinally be vertically sliced with event names.`;
   public static flags = {
     cpuThrottleRate: cpuThrottleRate({ required: true }),
-    tbResultsFile: tbResultsFile({ required: true }),
+    tbResultsFolder: tbResultsFolder({ required: true }),
     network: network(),
     url: url({ required: true }),
     iterations: iterations({ required: true }),
@@ -43,20 +43,20 @@ export default class Trace extends Command {
     const {
       url,
       cpuThrottleRate,
-      tbResultsFile,
+      tbResultsFolder,
       insights,
       json,
       locations,
     } = flags;
     const network = 'none';
     const cpu = cpuThrottleRate;
-    const file = tbResultsFile;
+    const file = tbResultsFolder;
     const event = undefined;
     const report = undefined;
     const methods = [''];
-    const traceJSON = path.join(tbResultsFile, 'trace.json');
-    const traceHAR = path.join(tbResultsFile, 'trace.har');
-    const cookiesJSON = path.join(tbResultsFile, 'cookies.json');
+    const traceJSON = path.join(tbResultsFolder, 'trace.json');
+    const traceHAR = path.join(tbResultsFolder, 'trace.har');
+    const cookiesJSON = path.join(tbResultsFolder, 'cookies.json');
 
     let archiveFile;
     let rawTraceData;
@@ -64,7 +64,7 @@ export default class Trace extends Command {
 
     // if trace can't find a HAR then go and record one
     if (!fs.existsSync(traceHAR)) {
-      await harTrace(url, tbResultsFile);
+      await harTrace(url, tbResultsFolder);
     }
 
     try {

--- a/packages/cli/src/helpers/default-flag-args.ts
+++ b/packages/cli/src/helpers/default-flag-args.ts
@@ -61,7 +61,7 @@ export const defaultFlagArgs: ITBConfig = {
   ],
   methods: '""',
   fidelity: 'low',
-  tbResultsFile: './tracerbench-results',
+  tbResultsFolder: './tracerbench-results',
   url: 'http://localhost:8000/',
   controlURL: 'http://localhost:8000/',
   experimentURL: 'http://localhost:8001/',

--- a/packages/cli/src/helpers/flags.ts
+++ b/packages/cli/src/helpers/flags.ts
@@ -139,9 +139,9 @@ export const network = flags.build({
   },
 });
 
-export const tbResultsFile = flags.build({
+export const tbResultsFolder = flags.build({
   default: () =>
-    getConfigDefault('tbResultsFile', defaultFlagArgs.tbResultsFile),
+    getConfigDefault('tbResultsFolder', defaultFlagArgs.tbResultsFolder),
   description: 'The output filepath for all tracerbench results',
 });
 

--- a/packages/cli/src/helpers/log-compare-results.ts
+++ b/packages/cli/src/helpers/log-compare-results.ts
@@ -17,7 +17,7 @@ export function logCompareResults(
     markers,
     fidelity,
     json,
-    tbResultsFile,
+    tbResultsFolder,
     browserArgs,
     regressionThreshold,
   } = flags;
@@ -43,7 +43,7 @@ export function logCompareResults(
   benchmarkTable.display.push(new Stats(getQueryData('duration')));
   benchmarkTable.display.push(new Stats(getQueryData('js')));
 
-  // iterate over the markers passed into the tbResultsFile command
+  // iterate over the markers passed into the tbResultsFolder command
   markers.forEach(marker => {
     // get the marker data for each phase
     const phase = getQueryData('phases', marker);
@@ -53,7 +53,7 @@ export function logCompareResults(
   const browser = browserArgs.includes('--headless')
     ? 'Headless-Chrome'
     : 'Chrome';
-  const message = `Success! ${fidelity} test samples were run with ${browser}. The json file with results from the compare test are available here: ${tbResultsFile}/compare.json.`;
+  const message = `Success! ${fidelity} test samples were run with ${browser}. The json file with results from the compare test are available here: ${tbResultsFolder}/compare.json.`;
   const sigMessage = `Statistically significant results were found. A recommended "fidelity=high" compare test should be run to rule out false negatives.`;
   const regThresholdMessage = `A regression was found exceeding the set regression threshold of ${regressionThreshold}μs`;
   const jsonResults = {

--- a/packages/cli/src/helpers/tb-config.ts
+++ b/packages/cli/src/helpers/tb-config.ts
@@ -11,7 +11,7 @@ export interface ITBConfig {
   event?: string;
   markers?: string | string[] | IMarker[] | PerformanceTimingMark[];
   network?: keyof INetworkConditions;
-  tbResultsFile?: string;
+  tbResultsFolder?: string;
   url?: string;
   controlURL?: string;
   experimentURL?: string;

--- a/packages/cli/tb-schema.json
+++ b/packages/cli/tb-schema.json
@@ -182,7 +182,7 @@
             "minItems": 2,
             "type": "array"
         },
-        "tbResultsFile": {
+        "tbResultsFolder": {
             "type": "string"
         },
         "traceFrame": {

--- a/packages/cli/test/commands/compare.test.ts
+++ b/packages/cli/test/commands/compare.test.ts
@@ -6,7 +6,7 @@ import { tmpDir } from '../setup';
 import { defaultFlagArgs } from '../../src/helpers/default-flag-args';
 
 const fidelity = 'test';
-const tbResultsFile = path.join(`${process.cwd()}/${tmpDir}`);
+const tbResultsFolder = path.join(`${process.cwd()}/${tmpDir}`);
 const emulateDevice = 'iphone-4';
 const regressionThreshold = '-100ms';
 
@@ -28,7 +28,7 @@ describe('compare fixture: A/A', () => {
     .it(
       `runs compare --controlURL ${app.control +
         defaultFlagArgs.tracingLocationSearch} --experimentURL ${app.control +
-        defaultFlagArgs.tracingLocationSearch} --fidelity ${fidelity} --tbResultsFile ${tbResultsFile} --cpuThrottleRate=1`,
+        defaultFlagArgs.tracingLocationSearch} --fidelity ${fidelity} --tbResultsFolder ${tbResultsFolder} --cpuThrottleRate=1`,
       async ctx => {
         await Compare.run([
           '--controlURL',
@@ -37,8 +37,8 @@ describe('compare fixture: A/A', () => {
           app.control,
           '--fidelity',
           fidelity,
-          '--tbResultsFile',
-          tbResultsFile,
+          '--tbResultsFolder',
+          tbResultsFolder,
           '--cpuThrottleRate=1',
         ]);
 
@@ -53,7 +53,7 @@ describe('compare regression: fixture: A/B', () => {
     .it(
       `runs compare --controlURL ${app.control +
         defaultFlagArgs.tracingLocationSearch} --experimentURL ${app.regression +
-        defaultFlagArgs.tracingLocationSearch} --fidelity=medium --tbResultsFile ${tbResultsFile} --regressionThreshold ${regressionThreshold} --cpuThrottleRate=1`,
+        defaultFlagArgs.tracingLocationSearch} --fidelity=medium --tbResultsFolder ${tbResultsFolder} --regressionThreshold ${regressionThreshold} --cpuThrottleRate=1`,
       async ctx => {
         await Compare.run([
           '--controlURL',
@@ -64,8 +64,8 @@ describe('compare regression: fixture: A/B', () => {
           '--cpuThrottleRate=1',
           '--regressionThreshold',
           regressionThreshold,
-          '--tbResultsFile',
-          tbResultsFile,
+          '--tbResultsFolder',
+          tbResultsFolder,
           '--json',
         ]);
 
@@ -82,7 +82,7 @@ describe('compare mobile: fixture: A/A', () => {
     .it(
       `runs compare --controlURL ${app.control +
         defaultFlagArgs.tracingLocationSearch} --experimentURL ${app.experiment +
-        defaultFlagArgs.tracingLocationSearch} --fidelity ${fidelity} --tbResultsFile ${tbResultsFile} --emulateDevice ${emulateDevice} --cpuThrottleRate=6`,
+        defaultFlagArgs.tracingLocationSearch} --fidelity ${fidelity} --tbResultsFolder ${tbResultsFolder} --emulateDevice ${emulateDevice} --cpuThrottleRate=6`,
       async ctx => {
         await Compare.run([
           '--controlURL',
@@ -91,8 +91,8 @@ describe('compare mobile: fixture: A/A', () => {
           app.experiment,
           '--fidelity',
           fidelity,
-          '--tbResultsFile',
-          tbResultsFile,
+          '--tbResultsFolder',
+          tbResultsFolder,
           '--emulateDevice',
           emulateDevice,
           '--cpuThrottleRate=6',

--- a/packages/cli/test/commands/create-archive.ts
+++ b/packages/cli/test/commands/create-archive.ts
@@ -6,24 +6,24 @@ import { tmpDir } from '../setup';
 chai.use(require('chai-fs'));
 
 const url = 'https://www.tracerbench.com';
-const tbResultsFile = path.join(`${process.cwd()}/${tmpDir}`);
+const tbResultsFolder = path.join(`${process.cwd()}/${tmpDir}`);
 
 describe('create-archive', () => {
   test
     .stdout()
     .it(
-      `runs create-archive --url ${url} --tbResultsFile ${tbResultsFile}`,
+      `runs create-archive --url ${url} --tbResultsFolder ${tbResultsFolder}`,
       async ctx => {
         await CreateArchive.run([
           '--url',
           url,
-          '--tbResultsFile',
-          tbResultsFile,
+          '--tbResultsFolder',
+          tbResultsFolder,
         ]);
         chai
           .expect(ctx.stdout)
           .to.contain(`HAR & cookies.json successfully generated`);
-        chai.expect(`${tbResultsFile}/trace.har`).to.be.a.file();
+        chai.expect(`${tbResultsFolder}/trace.har`).to.be.a.file();
       }
     );
 });

--- a/packages/cli/test/commands/marker-timings.test.ts
+++ b/packages/cli/test/commands/marker-timings.test.ts
@@ -6,20 +6,20 @@ import { tmpDir } from '../setup';
 
 chai.use(require('chai-fs'));
 
-const tbResultsFile = path.join(`${process.cwd()}/${tmpDir}`);
+const tbResultsFolder = path.join(`${process.cwd()}/${tmpDir}`);
 const url = 'https://www.tracerbench.com';
 
 describe('marker-timings', () => {
   test
     .stdout()
     .it(
-      `runs marker-timings --url ${url} --tbResultsFile ${tbResultsFile}`,
+      `runs marker-timings --url ${url} --tbResultsFolder ${tbResultsFolder}`,
       async ctx => {
         await MarkerTimings.run([
           '--url',
           url,
-          '--tbResultsFile',
-          tbResultsFile,
+          '--tbResultsFolder',
+          tbResultsFolder,
         ]);
         chai.expect(ctx.stdout).to.contain(`Marker Timings:`);
       }

--- a/packages/cli/test/commands/trace.ts
+++ b/packages/cli/test/commands/trace.ts
@@ -6,7 +6,7 @@ import { tmpDir } from '../setup';
 
 chai.use(require('chai-fs'));
 
-const tbResultsFile = path.join(`${process.cwd()}/${tmpDir}`);
+const tbResultsFolder = path.join(`${process.cwd()}/${tmpDir}`);
 const url = 'https://www.tracerbench.com';
 const cpuThrottleRate = '1';
 
@@ -14,19 +14,19 @@ describe('trace', () => {
   test
     .stdout()
     .it(
-      `runs trace --url ${url} --tbResultsFile ${tbResultsFile} --cpuThrottleRate ${cpuThrottleRate}`,
+      `runs trace --url ${url} --tbResultsFolder ${tbResultsFolder} --cpuThrottleRate ${cpuThrottleRate}`,
       async ctx => {
         await Trace.run([
           '--url',
           url,
-          '--tbResultsFile',
-          tbResultsFile,
+          '--tbResultsFolder',
+          tbResultsFolder,
           '--cpuThrottleRate',
           cpuThrottleRate,
         ]);
         chai.expect(ctx.stdout).to.contain(`Trace`);
         chai.expect(ctx.stdout).to.contain(`Subtotal`);
-        chai.expect(`${tbResultsFile}/trace.json`).to.be.a.file();
+        chai.expect(`${tbResultsFolder}/trace.json`).to.be.a.file();
       }
     );
 });
@@ -35,13 +35,13 @@ describe('trace :: insights', () => {
   test
     .stdout()
     .it(
-      `runs trace --url ${url} --tbResultsFile ${tbResultsFile} --cpuThrottleRate ${cpuThrottleRate} --insights`,
+      `runs trace --url ${url} --tbResultsFolder ${tbResultsFolder} --cpuThrottleRate ${cpuThrottleRate} --insights`,
       async ctx => {
         await Trace.run([
           '--url',
           url,
-          '--tbResultsFile',
-          tbResultsFile,
+          '--tbResultsFolder',
+          tbResultsFolder,
           '--cpuThrottleRate',
           cpuThrottleRate,
           '--insights',

--- a/packages/cli/test/helpers/log-compare-results.test.ts
+++ b/packages/cli/test/helpers/log-compare-results.test.ts
@@ -14,7 +14,7 @@ const markers = [
     label: 'domComplete',
   },
 ];
-const tbResultsFile = path.join(`${process.cwd()}/${tmpDir}`);
+const tbResultsFolder = path.join(`${process.cwd()}/${tmpDir}`);
 const scope = console;
 const network = {
   offline: false,
@@ -29,7 +29,7 @@ const flags = {
   fidelity: 2,
   markers,
   network,
-  tbResultsFile,
+  tbResultsFolder,
   controlURL: '',
   experimentURL: '',
   tracingLocationSearch: '',

--- a/packages/cli/test/tbconfig.json
+++ b/packages/cli/test/tbconfig.json
@@ -4,7 +4,7 @@
   "plotTitle": "TracerBench CLI",
   "fidelity": "low",
   "cpuThrottleRate": 2,
-  "tbResultsFile": "tracerbench-results",
+  "tbResultsFolder": "tracerbench-results",
   "controlURL": "https://www.tracerbench.com/",
   "experimentURL": "https://www.tracerbench.com/",
   "url": "https://www.tracerbench.com/",


### PR DESCRIPTION
Changing references of tbResultsFile to tbResultsFolder since we are using it as a folder path.