### PR TITLE
Control and experiment specific environment overrides from tbconfig

### DIFF
--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { Network } from 'chrome-debugging-client/dist/protocol/tot';
 import { Command } from '@oclif/command';
 import {
+  IInitialRenderBenchmarkParams,
   InitialRenderBenchmark,
   Runner,
   networkConditions,
@@ -28,8 +29,9 @@ import {
 } from '../helpers/flags';
 import { fidelityLookup } from '../helpers/default-flag-args';
 import { logCompareResults } from '../helpers/log-compare-results';
-import { parseMarkers, convertMSToMicroseconds } from '../helpers/utils';
-import deviceSettings, { EmulateDeviceSetting , EmulateDeviceSettingCliOption } from '../helpers/simulate-device-options';
+import { checkEnvironmentSpecificOverride, convertMSToMicroseconds, getTBConfigFromFile, parseMarkers } from '../helpers/utils';
+import { getEmulateDeviceSettingForKeyAndOrientation } from '../helpers/simulate-device-options';
+import { CONTROL_ENV_OVERRIDE_ATTR, EXPERIMENT_ENV_OVERRIDE_ATTR } from '../helpers/tb-config';
 
 export interface ICompareFlags {
   browserArgs: string[];
@@ -51,8 +53,7 @@ export interface ICompareFlags {
 }
 
 export default class Compare extends Command {
-  public static description =
-    'Compare the performance delta between an experiment and control';
+  public static description = 'Compare the performance delta between an experiment and control';
   public static flags = {
     browserArgs: browserArgs({ required: true }),
     cpuThrottleRate: cpuThrottleRate({ required: true }),
@@ -78,14 +79,9 @@ export default class Compare extends Command {
       tbResultsFolder,
       debug,
       fidelity,
-      network,
       markers,
-      emulateDevice,
-      emulateDeviceOrientation,
-      regressionThreshold,
+      regressionThreshold
     } = flags as ICompareFlags;
-    const delay = 100;
-    let parsedEmulationDeviceSetting: EmulateDeviceSetting | undefined;
 
     // modifies properties of flags that were not set
     // during flag.parse(). these are intentionally
@@ -104,9 +100,6 @@ export default class Compare extends Command {
     if (typeof fidelity === 'string') {
       flags.fidelity = parseInt((fidelityLookup as any)[fidelity], 10);
     }
-    if (typeof network === 'string') {
-      flags.network = networkConditions[network];
-    }
     if (typeof markers === 'string') {
       flags.markers = parseMarkers(markers);
     }
@@ -120,48 +113,13 @@ export default class Compare extends Command {
           : convertMSToMicroseconds(regressionThreshold);
     }
 
-    if (emulateDevice) {
-      let option: EmulateDeviceSettingCliOption;
-      for (option of deviceSettings) {
-        if (emulateDevice === option.typeable) {
-          if (!option.screens[emulateDeviceOrientation!]) {
-            this.error(`${emulateDeviceOrientation} orientation for ${emulateDevice} does not exist.`);
-          }
-          parsedEmulationDeviceSetting = {
-            width: option.screens[emulateDeviceOrientation!].width,
-            height: option.screens[emulateDeviceOrientation!].height,
-            deviceScaleFactor: option.deviceScaleFactor,
-            mobile: option.mobile,
-            userAgent: option.userAgent,
-            typeable: option.typeable
-          };
-          break;
-        }
-      }
-    }
     // if the folder for the tracerbench results file
     // does not exist then create it
     if (!fs.existsSync(tbResultsFolder)) {
       fs.mkdirSync(tbResultsFolder);
     }
 
-    // config for the browsers
-    const controlBrowser = {
-      additionalArguments: flags.browserArgs,
-    };
-    const experimentBrowser = {
-      additionalArguments: flags.browserArgs,
-    };
-    // config for the browswers to leverage socks proxy
-    if (flags.socksPorts) {
-      controlBrowser.additionalArguments.push(
-        `--proxy-server=socks5://0.0.0.0:${flags.socksPorts[0]}`
-      );
-      experimentBrowser.additionalArguments.push(
-        `--proxy-server=socks5://0.0.0.0:${flags.socksPorts[1]}`
-      );
-    }
-
+    const [controlSettings, experimentSettings] = this.generateControlExperimentEnvironmentSettings(flags);
     // if debug flag then log X post mutations
     if (debug) {
       this.log(`\n FLAGS: ${JSON.stringify(flags)}`);
@@ -169,30 +127,8 @@ export default class Compare extends Command {
 
     // todo: leverage har-remix?
     const benchmarks = {
-      control: new InitialRenderBenchmark({
-        browser: controlBrowser,
-        cpuThrottleRate: flags.cpuThrottleRate,
-        delay,
-        emulateDeviceSettings: parsedEmulationDeviceSetting,
-        markers: flags.markers,
-        networkConditions: flags.network,
-        name: 'control',
-        runtimeStats: flags.runtimeStats,
-        saveTraces: () => `${flags.tbResultsFolder}/control.json`,
-        url: path.join(flags.controlURL + flags.tracingLocationSearch),
-      }),
-      experiment: new InitialRenderBenchmark({
-        browser: experimentBrowser,
-        cpuThrottleRate: flags.cpuThrottleRate,
-        delay,
-        emulateDeviceSettings: parsedEmulationDeviceSetting,
-        markers: flags.markers,
-        networkConditions: flags.network,
-        name: 'experiment',
-        runtimeStats: flags.runtimeStats,
-        saveTraces: () => `${flags.tbResultsFolder}/experiment.json`,
-        url: path.join(flags.experimentURL + flags.tracingLocationSearch),
-      }),
+      control: new InitialRenderBenchmark(controlSettings),
+      experiment: new InitialRenderBenchmark(experimentSettings),
     };
 
     const runner = new Runner([benchmarks.control, benchmarks.experiment]);
@@ -203,22 +139,99 @@ export default class Compare extends Command {
           this.error(
             `Could not sample from provided urls\nCONTROL: ${
               flags.controlURL
-            }\nEXPERIMENT: ${flags.experimentURL}.`
+              }\nEXPERIMENT: ${flags.experimentURL}.`,
           );
         }
 
         fs.writeFileSync(
           `${flags.tbResultsFolder}/compare.json`,
-          JSON.stringify(results, null, 2)
+          JSON.stringify(results, null, 2),
         );
 
         fs.writeFileSync(
           `${flags.tbResultsFolder}/compare-stat-results.json`,
-          JSON.stringify(logCompareResults(results, flags, this), null, 2)
+          JSON.stringify(logCompareResults(results, flags, this), null, 2),
         );
       })
       .catch((err: any) => {
         this.error(err);
       });
   }
-}
+
+
+  /**
+   * Final result of the configs are in the following order:
+   *
+   * controlConfigs = tbconfig:controlBenchmarkEnvironment > command line > tbconfig > default
+   * experimentConfigs = tbconfig:experimentBenchmarkEnvironment > command line > tbconfig > default
+   *
+   * This functions handles the tsconfig:** part since it is assumed that parent function that passed input "flags"
+   * would've handled "command line > tbconfig > default"
+   *
+   * @param flags - Object containing configs parsed from the Command class
+   */
+  private generateControlExperimentEnvironmentSettings(flags: ICompareFlags): [IInitialRenderBenchmarkParams, IInitialRenderBenchmarkParams] {
+    const delay = 100;
+    const controlBrowser = { additionalArguments: flags.browserArgs };
+    const experimentBrowser = { additionalArguments: flags.browserArgs };
+    let controlNetwork: string;
+    let experimentNetwork: string;
+    let experimentEmulateDevice;
+    let experimentEmulateDeviceOrientation;
+    let controlEmulateDevice;
+    let controlEmulateDeviceOrientation;
+    let controlSettings;
+    let experimentSettings;
+    let tbConfig;
+
+    try {
+      [ tbConfig ] = getTBConfigFromFile();
+    } catch {
+      tbConfig = undefined;
+    }
+
+    // config for the browsers to leverage socks proxy
+    if (flags.socksPorts) {
+      controlBrowser.additionalArguments.push(
+        `--proxy-server=socks5://0.0.0.0:${flags.socksPorts[0]}`,
+      );
+      experimentBrowser.additionalArguments.push(
+        `--proxy-server=socks5://0.0.0.0:${flags.socksPorts[1]}`,
+      );
+    }
+
+    controlNetwork = checkEnvironmentSpecificOverride('network', flags, CONTROL_ENV_OVERRIDE_ATTR, tbConfig);
+    controlEmulateDevice = checkEnvironmentSpecificOverride('emulateDevice', flags, CONTROL_ENV_OVERRIDE_ATTR, tbConfig);
+    controlEmulateDeviceOrientation = checkEnvironmentSpecificOverride('emulateDeviceOrientation', flags, CONTROL_ENV_OVERRIDE_ATTR, tbConfig);
+    experimentNetwork = checkEnvironmentSpecificOverride('network', flags, EXPERIMENT_ENV_OVERRIDE_ATTR, tbConfig);
+    experimentEmulateDevice = checkEnvironmentSpecificOverride('emulateDevice', flags, EXPERIMENT_ENV_OVERRIDE_ATTR, tbConfig);
+    experimentEmulateDeviceOrientation = checkEnvironmentSpecificOverride('emulateDeviceOrientation', flags, EXPERIMENT_ENV_OVERRIDE_ATTR, tbConfig);
+
+    controlSettings = {
+      browser: controlBrowser,
+      cpuThrottleRate: checkEnvironmentSpecificOverride('cpuThrottleRate', flags, CONTROL_ENV_OVERRIDE_ATTR, tbConfig),
+      delay,
+      emulateDeviceSettings: getEmulateDeviceSettingForKeyAndOrientation(controlEmulateDevice, controlEmulateDeviceOrientation),
+      markers: flags.markers,
+      networkConditions: controlNetwork ? networkConditions[controlNetwork] : flags.network,
+      name: 'control',
+      runtimeStats: flags.runtimeStats,
+      saveTraces: () => `${flags.tbResultsFolder}/control.json`,
+      url: path.join(flags.controlURL + flags.tracingLocationSearch),
+    };
+
+    experimentSettings = {
+      browser: experimentBrowser,
+      cpuThrottleRate: checkEnvironmentSpecificOverride('cpuThrottleRate', flags, EXPERIMENT_ENV_OVERRIDE_ATTR, tbConfig),
+      delay,
+      emulateDeviceSettings: getEmulateDeviceSettingForKeyAndOrientation(experimentEmulateDevice, experimentEmulateDeviceOrientation),
+      markers: flags.markers,
+      networkConditions: experimentNetwork ? networkConditions[experimentNetwork] : flags.network,
+      name: 'experiment',
+      runtimeStats: flags.runtimeStats,
+      saveTraces: () => `${flags.tbResultsFolder}/experiment.json`,
+      url: path.join(flags.experimentURL + flags.tracingLocationSearch),
+    };
+
+    return [controlSettings, experimentSettings];
+  }}

--- a/packages/cli/src/helpers/simulate-device-options.ts
+++ b/packages/cli/src/helpers/simulate-device-options.ts
@@ -43,4 +43,31 @@ const deviceSettings: EmulateDeviceSettingCliOption[] = simulateDeviceOptions.ma
   }
 );
 
+/**
+ * Iterate over deviceSettings until a match is found in the option's typable field. Extract the contents into EmulateDeviceSetting
+ * formatted object
+ *
+ * @param key - One of typeable strings such as iphone-x
+ * @param orientation - Either "vertical" or "horizontal"
+ */
+export function getEmulateDeviceSettingForKeyAndOrientation(key: string, orientation: string = 'vertical'): EmulateDeviceSetting | undefined {
+  let deviceSetting;
+
+  for (deviceSetting of deviceSettings) {
+    if (key === deviceSetting.typeable) {
+      if (!deviceSetting.screens[orientation!]) {
+        throw new Error(`${orientation} orientation for ${key} does not exist.`);
+      }
+      return {
+        width: deviceSetting.screens[orientation!].width,
+        height: deviceSetting.screens[orientation!].height,
+        deviceScaleFactor: deviceSetting.deviceScaleFactor,
+        mobile: deviceSetting.mobile,
+        userAgent: deviceSetting.userAgent,
+        typeable: deviceSetting.typeable,
+      };
+    }
+  }
+}
+
 export default deviceSettings;

--- a/packages/cli/src/helpers/tb-config.ts
+++ b/packages/cli/src/helpers/tb-config.ts
@@ -2,6 +2,9 @@ import { IMarker } from 'tracerbench';
 import { PerformanceTimingMark } from './default-flag-args';
 import { Network } from 'chrome-debugging-client/dist/protocol/tot';
 
+export const CONTROL_ENV_OVERRIDE_ATTR = 'controlBenchmarkEnvironment';
+export const EXPERIMENT_ENV_OVERRIDE_ATTR = 'experimentBenchmarkEnvironment';
+
 export interface ITBConfig {
   plotTitle?: string;
   methods?: string;
@@ -28,6 +31,19 @@ export interface ITBConfig {
   emulateDeviceOrientation?: string;
   socksPorts?: [string, string];
   regressionThreshold?: number | string;
+
+  // Optional overrides specific to control or experiment benchmark environments
+  [CONTROL_ENV_OVERRIDE_ATTR]?: IBenchmarkEnvironmentOverride;
+  [EXPERIMENT_ENV_OVERRIDE_ATTR]?: IBenchmarkEnvironmentOverride;
+  [key: string]: any;
+}
+
+export interface IBenchmarkEnvironmentOverride {
+  cpuThrottle?: number;
+  network?: keyof INetworkConditions;
+  emulateDevice?: string;
+  emulateDeviceOrientation?: string;
+  [key: string]: any;
 }
 
 export interface INetworkConditions {

--- a/packages/cli/tb-schema.json
+++ b/packages/cli/tb-schema.json
@@ -1,6 +1,43 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": {
+    },
     "definitions": {
+        "IBenchmarkEnvironmentOverride": {
+            "additionalProperties": {
+            },
+            "properties": {
+                "cpuThrottle": {
+                    "type": "number"
+                },
+                "emulateDevice": {
+                    "type": "string"
+                },
+                "emulateDeviceOrientation": {
+                    "type": "string"
+                },
+                "network": {
+                    "enum": [
+                        "2g",
+                        "3g",
+                        "4g",
+                        "FIOS",
+                        "LTE",
+                        "cable",
+                        "dialup",
+                        "dsl",
+                        "edge",
+                        "em-3g",
+                        "fast-3g",
+                        "none",
+                        "offline",
+                        "slow-3g"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "IMarker": {
             "properties": {
                 "label": {
@@ -25,6 +62,9 @@
             },
             "type": "array"
         },
+        "controlBenchmarkEnvironment": {
+            "$ref": "#/definitions/IBenchmarkEnvironmentOverride"
+        },
         "controlURL": {
             "type": "string"
         },
@@ -42,6 +82,9 @@
         },
         "event": {
             "type": "string"
+        },
+        "experimentBenchmarkEnvironment": {
+            "$ref": "#/definitions/IBenchmarkEnvironmentOverride"
         },
         "experimentURL": {
             "type": "string"

--- a/packages/cli/test/helpers/simulate-device-options.test.ts
+++ b/packages/cli/test/helpers/simulate-device-options.test.ts
@@ -1,0 +1,18 @@
+import {
+  getEmulateDeviceSettingForKeyAndOrientation
+} from '../../src/helpers/simulate-device-options';
+import { expect } from 'chai';
+
+
+describe('simulate-device-options', () => {
+  it(`getEmulateDeviceSettingForKeyAndOrientation() with non-existent device`, () => {
+    const result = getEmulateDeviceSettingForKeyAndOrientation('not-exist');
+    expect(result).to.equal(undefined);
+  });
+
+  it(`getEmulateDeviceSettingForKeyAndOrientation() success path`, () => {
+    const result = getEmulateDeviceSettingForKeyAndOrientation('iphone-x');
+    expect(result !== undefined).to.equal(true);
+    expect(typeof result!.height).to.equal('number');
+  });
+});

--- a/packages/cli/test/helpers/utils.test.ts
+++ b/packages/cli/test/helpers/utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  checkEnvironmentSpecificOverride,
   findFrame,
   isCommitLoad,
   isFrameNavigationStart,
@@ -61,5 +62,38 @@ describe('utils', () => {
 
   it(`convertMSToMicroseconds()`, () => {
     expect(micro).to.equal(-100000);
+  });
+});
+
+
+describe('checkEnvironmentSpecificOverride', () => {
+  it(`tbConfig missing case`, () => {
+    const defaultValues = { 'network': 'defaultValue' };
+    // @ts-ignore
+    const result = checkEnvironmentSpecificOverride('network', defaultValues, 'overrideName');
+    expect(result).to.equal('defaultValue');
+  });
+
+  it(`tbConfig exists but environment config missing case`, () => {
+    const defaultValues = { 'network': 'defaultValue' };
+    // @ts-ignore
+    const result = checkEnvironmentSpecificOverride('network', defaultValues, 'overrideName', {});
+    expect(result).to.equal('defaultValue');
+  });
+
+  it(`tbConfig exists and environment exists but config missing case`, () => {
+    const defaultValues = { 'network': 'defaultValue' };
+    const tbConfig = { overrideName: { cpuThrottleRate: 1 } };
+    // @ts-ignore
+    const result = checkEnvironmentSpecificOverride('network', defaultValues, 'overrideName', tbConfig);
+    expect(result).to.equal('defaultValue');
+  });
+
+  it(`tbConfig exists and environment exists and config exists case`, () => {
+    const defaultValues = { 'cpuThrottleRate': 100 };
+    const tbConfig = { overrideName: { cpuThrottleRate: 1 } };
+    // @ts-ignore
+    const result = checkEnvironmentSpecificOverride('cpuThrottleRate', defaultValues, 'overrideName', tbConfig);
+    expect(result).to.equal(1);
   });
 });

--- a/packages/tracerbench/src/trace/conditions.ts
+++ b/packages/tracerbench/src/trace/conditions.ts
@@ -20,6 +20,7 @@ export interface INetworkConditions {
   '4g': Network.EmulateNetworkConditionsParameters;
   LTE: Network.EmulateNetworkConditionsParameters;
   FIOS: Network.EmulateNetworkConditionsParameters;
+  [key: string]: Network.EmulateNetworkConditionsParameters;
 }
 
 export const networkConditions: INetworkConditions = {


### PR DESCRIPTION
### High Level
Code changes introduced in this PR supports overriding the settings to the InitialRenderBenchmark for the experiment and control runs through TB Config file.

The expected format in the tbconfig file is:
```
...
"controlBenchmarkEnvironment": {
  "cpuThrottleRate": 6,
  "emulateDevice": "iphone-x",
  "emulateDeviceOrientation": "vertical",
  "networkConditions": "slow-3g"
},
"experimentBenchmarkEnvironment": {
  "cpuThrottleRate": 6,
  "emulateDevice": "iphone-x",
  "emulateDeviceOrientation": "vertical",
  "networkConditions": "slow-3g"
}
```

The precedence order becomes: **tbconfig:experimentBenchmarkEnvironment > command line > tbconfig > default** where default is the lowest priority

### Implementation
I moved the bulk of the code that generated the settings for the InitialRenderBenchmark class into another function called **generateControlExperimentEnvironmentSettings**. That function determines what to use for the experiment and control