### PR TITLE
feat(cli): fidelity accepts an int, bump high 50

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -230,7 +230,7 @@ OPTIONS
   --experimentURL=experimentURL
       (required) [default: http://localhost:8001/] Experiment URL to visit for compare command
 
-  --fidelity=test|low|medium|high
+  --fidelity=fidelity
       (required) [default: low] Directly correlates to the number of samples per trace. High is the longest trace time.
 
   --headless

--- a/packages/cli/src/command-config/default-flag-args.ts
+++ b/packages/cli/src/command-config/default-flag-args.ts
@@ -4,7 +4,7 @@ export const fidelityLookup = {
   test: 2,
   low: 20,
   medium: 30,
-  high: 40,
+  high: 50,
 };
 
 export type PerformanceTimingMark = keyof PerformanceNavigationTiming;
@@ -66,6 +66,7 @@ export const defaultFlagArgs: ITBConfig = {
 };
 
 // specify with --headless flag
+// ! --disable-gpu might cause issues with RHEL7
 export const headlessFlags = [
   '--headless',
   '--disable-gpu',

--- a/packages/cli/src/command-config/tb-config.ts
+++ b/packages/cli/src/command-config/tb-config.ts
@@ -11,7 +11,7 @@ export interface ITBConfig {
   plotTitle?: string;
   methods?: string;
   cpuThrottleRate?: number | string;
-  fidelity?: 'test' | 'low' | 'medium' | 'high';
+  fidelity?: 'test' | 'low' | 'medium' | 'high' | number;
   report?: string;
   event?: string;
   markers?: string | string[] | IMarker[] | PerformanceTimingMark[];

--- a/packages/cli/src/helpers/flags.ts
+++ b/packages/cli/src/helpers/flags.ts
@@ -19,7 +19,7 @@ import deviceSettings from './simulate-device-options';
 
 export const runtimeStats = flags.boolean({
   description: `Compare command output deep-dive stats during run.`,
-  default: false
+  default: false,
 });
 
 export const servers = flags.build({
@@ -115,9 +115,24 @@ export const cpuThrottleRate = flags.build({
 export const fidelity = flags.build({
   default: () => getDefaultValue('fidelity'),
   description: `Directly correlates to the number of samples per trace. High is the longest trace time.`,
-  options: Object.keys(fidelityLookup),
-  parse: (fidelity: string): number => {
-    return parseInt((fidelityLookup as any)[fidelity], 10);
+  parse: (fidelity: string | number): number => {
+    const warnMessage = `Expected --fidelity=${fidelity} to be either a number or one of: ${Object.keys(
+      fidelityLookup
+    )}. Defaulting to ${getDefaultValue('fidelity')}`;
+
+    if (typeof fidelity === 'string') {
+      // integers are coming as string from oclif
+      if (Number.isInteger(parseInt(fidelity, 10))) {
+        return parseInt(fidelity, 10);
+      }
+      // is a string and is either test/low/med/high
+      if (Object.keys(fidelityLookup).includes(fidelity)) {
+        return parseInt((fidelityLookup as any)[fidelity], 10);
+      } else {
+        console.warn(`${warnMessage}`);
+      }
+    }
+    return fidelity === 'number' ? fidelity : getDefaultValue('fidelity');
   },
 });
 

--- a/packages/cli/tb-schema.json
+++ b/packages/cli/tb-schema.json
@@ -116,13 +116,20 @@
             "type": "string"
         },
         "fidelity": {
-            "enum": [
-                "high",
-                "low",
-                "medium",
-                "test"
-            ],
-            "type": "string"
+            "anyOf": [
+                {
+                    "enum": [
+                        "high",
+                        "low",
+                        "medium",
+                        "test"
+                    ],
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
         },
         "filter": {
             "type": "string"


### PR DESCRIPTION
This PR:
- allows fidelity to accept an integer
- defaults the fidelity=high to 50 samples 