### PR TITLE
feat(tracerbench/trace-utils): Accept additional browser arguments

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -201,9 +201,9 @@ OPTIONS
   --browserArgs=browserArgs
       (required) [default: 
       --crash-dumps-dir=./tmp,--disable-background-timer-throttling,--disable-dev-shm-usage,--disable-cache,--disable-v8-i
-      dle-tasks,--disable-breakpad,--disable-notifications,--disable-hang-monitor,--safebrowsing-disable-auto-update,--set
-      IgnoreCertificateErrors=true,--v8-cache-options=none] (Default Recommended) Additional chrome flags for the 
-      TracerBench render benchmark. TracerBench includes many non-configurable defaults in this category.
+      dle-tasks,--disable-breakpad,--disable-notifications,--disable-hang-monitor,--safebrowsing-disable-auto-update,--ign
+      ore-certificate-errors,--v8-cache-options=none] (Default Recommended) Additional chrome flags for the TracerBench 
+      render benchmark. TracerBench includes many non-configurable defaults in this category.
 
   --config=config
       Specify an alternative directory rather than the project root for the tbconfig.json. This explicit config will 
@@ -230,7 +230,7 @@ OPTIONS
   --experimentURL=experimentURL
       (required) [default: http://localhost:8001/] Experiment URL to visit for compare command
 
-  --fidelity=test|low|medium|high
+  --fidelity=fidelity
       (required) [default: low] Directly correlates to the number of samples per trace. High is the longest trace time.
 
   --headless
@@ -251,8 +251,8 @@ OPTIONS
   --report
       Generate a PDF report directly after running the compare command.
 
-  --runtimeStats=runtimeStats
-      (required) [default: false] Compare command output stats during run
+  --runtimeStats
+      Compare command output deep-dive stats during run.
 
   --socksPorts=socksPorts
       Specify a socks proxy port as browser option for control and experiment
@@ -273,11 +273,18 @@ USAGE
   $ tracerbench create-archive
 
 OPTIONS
-  --tbResultsFolder=tbResultsFolder  (required) [default: ./tracerbench-results] The output folder path for all
-                                     tracerbench results
+  --browserArgs=browserArgs
+      (required) [default: 
+      --crash-dumps-dir=./tmp,--disable-background-timer-throttling,--disable-dev-shm-usage,--disable-cache,--disable-v8-i
+      dle-tasks,--disable-breakpad,--disable-notifications,--disable-hang-monitor,--safebrowsing-disable-auto-update,--ign
+      ore-certificate-errors,--v8-cache-options=none] (Default Recommended) Additional chrome flags for the TracerBench 
+      render benchmark. TracerBench includes many non-configurable defaults in this category.
 
-  --url=url                          (required) [default: http://localhost:8000/] URL to visit for create-archive,
-                                     timings & trace commands
+  --tbResultsFolder=tbResultsFolder
+      (required) [default: ./tracerbench-results] The output folder path for all tracerbench results
+
+  --url=url
+      (required) [default: http://localhost:8000/] URL to visit for create-archive, timings & trace commands
 ```
 
 ## `tracerbench help [COMMAND]`

--- a/packages/cli/src/command-config/default-flag-args.ts
+++ b/packages/cli/src/command-config/default-flag-args.ts
@@ -49,7 +49,7 @@ export const defaultFlagArgs: ITBConfig = {
     '--disable-notifications',
     '--disable-hang-monitor',
     '--safebrowsing-disable-auto-update',
-    '--setIgnoreCertificateErrors=true',
+    '--ignore-certificate-errors',
     '--v8-cache-options=none',
   ],
   methods: '""',

--- a/packages/cli/src/commands/create-archive.ts
+++ b/packages/cli/src/commands/create-archive.ts
@@ -1,19 +1,20 @@
 import { Command } from '@oclif/command';
 import { harTrace } from '@tracerbench/core';
-import { tbResultsFolder, url } from '../helpers/flags';
+import { browserArgs, tbResultsFolder, url } from '../helpers/flags';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 
 export default class CreateArchive extends Command {
   public static description = 'Creates an automated HAR file from a URL.';
   public static flags = {
+    browserArgs: browserArgs({ required: true }),
     tbResultsFolder: tbResultsFolder({ required: true }),
-    url: url({ required: true }),
+    url: url({ required: true })
   };
 
   public async run() {
     const { flags } = this.parse(CreateArchive);
-    const { url, tbResultsFolder } = flags;
+    const { browserArgs, url, tbResultsFolder } = flags;
     const archiveOutput = path.join(tbResultsFolder, 'trace.har');
     const cookiesJSON = path.join(tbResultsFolder, 'cookies.json');
 
@@ -21,7 +22,7 @@ export default class CreateArchive extends Command {
       fs.mkdirSync(tbResultsFolder);
     }
 
-    await harTrace(url, tbResultsFolder);
+    await harTrace(url, tbResultsFolder, browserArgs);
     return this.log(
       `HAR & cookies.json successfully generated from ${url} and available here: ${archiveOutput} and ${cookiesJSON}`
     );

--- a/packages/cli/src/commands/create-archive.ts
+++ b/packages/cli/src/commands/create-archive.ts
@@ -17,12 +17,18 @@ export default class CreateArchive extends Command {
     const { browserArgs, url, tbResultsFolder } = flags;
     const archiveOutput = path.join(tbResultsFolder, 'trace.har');
     const cookiesJSON = path.join(tbResultsFolder, 'cookies.json');
+    let cookies;
+    let harArchive;
 
     if (!fs.existsSync(tbResultsFolder)) {
       fs.mkdirSync(tbResultsFolder);
     }
 
-    await harTrace(url, tbResultsFolder, browserArgs);
+    [cookies, harArchive] = await harTrace(url, browserArgs);
+    fs.writeFileSync(cookiesJSON, JSON.stringify(cookies));
+    fs.writeFileSync(archiveOutput, JSON.stringify(harArchive));
+
+    this.log(`Captured ${harArchive.log.entries.length} request responses in har file.`);
     return this.log(
       `HAR & cookies.json successfully generated from ${url} and available here: ${archiveOutput} and ${cookiesJSON}`
     );

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -64,7 +64,10 @@ export default class Trace extends Command {
 
     // if trace can't find a HAR then go and record one
     if (!fs.existsSync(traceHAR)) {
-      await harTrace(url, tbResultsFolder);
+      [cookies, archiveFile] = await harTrace(url);
+
+      fs.writeFileSync(cookiesJSON, JSON.stringify(cookies));
+      fs.writeFileSync(traceHAR, JSON.stringify(archiveFile));
     }
 
     try {

--- a/packages/tracerbench/src/trace/archive_trace.ts
+++ b/packages/tracerbench/src/trace/archive_trace.ts
@@ -34,6 +34,7 @@ export interface IEntry {
 export async function harTrace(
   url: string,
   outputPath: string,
+  additionalBrowserArgs: string[] = [],
   cookies: any = null
 ) {
 
@@ -45,7 +46,7 @@ export async function harTrace(
 
   // in the instance we are passing in the cookies
 
-  const browser = await createBrowser();
+  const browser = await createBrowser(additionalBrowserArgs);
   try {
     const client = await getTab(browser.connection);
     const traceHAR = path.join(outputPath, 'trace.har');

--- a/packages/tracerbench/src/trace/archive_trace.ts
+++ b/packages/tracerbench/src/trace/archive_trace.ts
@@ -1,8 +1,6 @@
 // tslint:disable:no-console
 
 import Protocol from 'devtools-protocol';
-import * as fs from 'fs';
-import * as path from 'path';
 import { createBrowser, getTab, setCookies } from './trace-utils';
 
 // Represents a subset of a HAR
@@ -31,12 +29,7 @@ export interface IEntry {
   response: IResponse;
 }
 
-export async function harTrace(
-  url: string,
-  outputPath: string,
-  additionalBrowserArgs: string[] = [],
-  cookies: any = null
-) {
+export async function harTrace(url: string, additionalBrowserArgs: string[] = [], cookies: any = null) {
 
   // the saving of the cookies should be a dif command
   // spawn browser > sign-in > done > save cookies
@@ -49,8 +42,6 @@ export async function harTrace(
   const browser = await createBrowser(additionalBrowserArgs);
   try {
     const client = await getTab(browser.connection);
-    const traceHAR = path.join(outputPath, 'trace.har');
-    const cookiesJSON = path.join(outputPath, 'cookies.json');
 
     const requestIds: string[] = [];
     const responses: Protocol.Network.Response[] = [];
@@ -82,7 +73,7 @@ export async function harTrace(
 
     await Promise.all([
       client.until('Page.loadEventFired'),
-      client.send('Page.navigate', { url })
+      client.send('Page.navigate', { url }),
     ]);
 
     for (let i = 0; i < requestIds.length; i++) {
@@ -95,9 +86,7 @@ export async function harTrace(
       };
       archive.log.entries.push(entry);
     }
-
-    fs.writeFileSync(cookiesJSON, JSON.stringify(cookies));
-    fs.writeFileSync(traceHAR, JSON.stringify(archive));
+    return [cookies, archive];
   } finally {
     await browser.dispose();
   }

--- a/packages/tracerbench/src/trace/trace-utils.ts
+++ b/packages/tracerbench/src/trace/trace-utils.ts
@@ -5,11 +5,13 @@ import Protocol from 'devtools-protocol';
 import { IConditions, networkConditions } from './conditions';
 import { filterObjectByKeys } from './utils';
 
-export async function createBrowser() {
-  const additionalArguments = ['--crash-dumps-dir=/tmp'];
+const DEFAULT_BROWSER_ARGS = ['--crash-dumps-dir=/tmp'];
+
+export async function createBrowser(additionalBrowserArgs: string[] = []) {
+  const mergedBrowserArgs = additionalBrowserArgs.concat(DEFAULT_BROWSER_ARGS);
 
   const browser = await spawnChrome({
-    additionalArguments,
+    additionalArguments: mergedBrowserArgs,
     stdio: 'inherit',
     chromeExecutable: undefined,
     userDataDir: undefined,


### PR DESCRIPTION
In order to fix invalid certificate issues when generating har file in development, I modified packages/tracerbench/src/trace/trace-utils.ts to take in additional browser args and merge it with the default original set. I modified packages/cli/src/commands/create-archive.ts to pass the global default browser args which includes the ignore invalid certificate error flag

There also has been some refactoring where the parent functions are expected to write the har and cookie output