### PR TITLE
Refactoring the output of the "compare" command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,7 +24,7 @@ $ npm install -g tracerbench
 $ tracerbench COMMAND
 running command...
 $ tracerbench (-v|--version|version)
-tracerbench/2.0.3 darwin-x64 node-v10.16.0
+tracerbench/2.0.5 darwin-x64 node-v10.16.0
 $ tracerbench --help [COMMAND]
 USAGE
   $ tracerbench COMMAND

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracerbench",
-  "version": "2.0.6",
+  "version": "2.0.5",
   "description": "CLI for Tracerbench",
   "keywords": [
     "oclif"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracerbench",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "CLI for Tracerbench",
   "keywords": [
     "oclif"

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -20,7 +20,6 @@ import {
   tbResultsFolder,
   tracingLocationSearch,
   runtimeStats,
-  json,
   debug,
   emulateDevice,
   emulateDeviceOrientation,
@@ -64,7 +63,6 @@ export interface ICompareFlags {
   emulateDevice?: string;
   emulateDeviceOrientation?: string;
   socksPorts?: [string, string] | [number, number] | undefined;
-  json: boolean;
   debug: boolean;
   regressionThreshold?: number;
   headless: boolean;
@@ -92,7 +90,6 @@ export default class Compare extends Command {
     config: config(),
     runtimeStats,
     report,
-    json,
     debug,
     headless,
   };

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -355,7 +355,7 @@ export default class Compare extends Command {
         `${this.compareFlags.tbResultsFolder}/traces/experiment${i}.json`,
       url: path.join(
         this.compareFlags.experimentURL +
-        this.compareFlags.tracingLocationSearch
+          this.compareFlags.tracingLocationSearch
       ),
     };
 

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -37,6 +37,7 @@ import {
 } from '../command-config/default-flag-args';
 import { logCompareResults } from '../helpers/log-compare-results';
 import {
+  chalkScheme,
   checkEnvironmentSpecificOverride,
   parseMarkers,
 } from '../helpers/utils';
@@ -175,7 +176,7 @@ export default class Compare extends Command {
 
         // if we want to run the Report without calling a separate command
         if (this.parsedConfig.report) {
-          this.log('RUNNING A REPORT');
+          this.log(chalkScheme.tbBranding.aqua('\nRUNNING A REPORT'));
           Report.run([
             '--tbResultsFolder',
             `${this.parsedConfig.tbResultsFolder}`,
@@ -354,7 +355,7 @@ export default class Compare extends Command {
         `${this.compareFlags.tbResultsFolder}/traces/experiment${i}.json`,
       url: path.join(
         this.compareFlags.experimentURL +
-          this.compareFlags.tracingLocationSearch
+        this.compareFlags.tracingLocationSearch
       ),
     };
 

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -152,14 +152,7 @@ export default class Compare extends Command {
           JSON.stringify(results, null, 2)
         );
 
-        fs.writeFileSync(
-          `${this.parsedConfig.tbResultsFolder}/compare-stat-results.json`,
-          JSON.stringify(
-            logCompareResults(results, this.compareFlags, this),
-            null,
-            2
-          )
-        );
+        logCompareResults(results, this.compareFlags, this);
 
         // with debug flag output three files
         // on config specifics

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -9,6 +9,7 @@ import createConsumeableHTML, {
 } from '../helpers/create-consumable-html';
 import { tbResultsFolder, config } from '../helpers/flags';
 import printToPDF from '../helpers/print-to-pdf';
+import { chalkScheme } from '../helpers/utils';
 
 const ARTIFACT_FILE_NAME = 'artifact';
 
@@ -106,7 +107,7 @@ export default class Report extends Command {
     await printToPDF(`file://${absPathToHTML}`, absOutputPath);
 
     this.log(
-      `The PDF and HTML reports are available here: ${absPathToHTML} and here: ${absOutputPath}`
+      `The PDF and HTML reports are available here: ${chalkScheme.tbBranding.lime.underline.bold(absPathToHTML)} and here: ${chalkScheme.tbBranding.blue.underline.bold(absOutputPath)}`
     );
   }
   private async parseFlags() {

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -15,7 +15,6 @@ import {
   network,
   url,
   insights,
-  json,
   locations,
 } from '../helpers/flags';
 import {
@@ -34,8 +33,7 @@ export default class Trace extends Command {
     url: url({ required: true }),
     iterations: iterations({ required: true }),
     locations: locations(),
-    insights,
-    json,
+    insights
   };
 
   public async run() {
@@ -45,7 +43,6 @@ export default class Trace extends Command {
       cpuThrottleRate,
       tbResultsFolder,
       insights,
-      json,
       locations,
     } = flags;
     const network = 'none';
@@ -114,12 +111,6 @@ export default class Trace extends Command {
       rawTraceData,
       report,
     });
-
-    if (json) {
-      return {
-        // handle json response
-      };
-    }
 
     if (insights) {
       // js-eval-time

--- a/packages/cli/src/helpers/create-consumable-html.ts
+++ b/packages/cli/src/helpers/create-consumable-html.ts
@@ -28,7 +28,7 @@ export interface ITracerBenchTraceResult {
   set: string;
 }
 
-interface HTMLSectionRenderData {
+export interface HTMLSectionRenderData {
   isSignificant: boolean;
   ciMin: number;
   ciMax: number;
@@ -45,7 +45,7 @@ interface ValuesByPhase {
  [key: string]: number[]
 }
 
-const PAGE_LOAD_TIME = 'duration';
+export const PAGE_LOAD_TIME = 'duration';
 
 const CHART_CSS_PATH = path.join(__dirname, '../static/chart-bootstrap.css');
 const CHART_JS_PATH = path.join(

--- a/packages/cli/src/helpers/flags.ts
+++ b/packages/cli/src/helpers/flags.ts
@@ -50,11 +50,6 @@ export const insights = flags.boolean({
   default: false,
 });
 
-export const json = flags.boolean({
-  description: `If supported output the command stdout with json rather than formatted results`,
-  default: false,
-});
-
 export const debug = flags.boolean({
   description: `Debug flag per command. Will output noisy command`,
   default: false,

--- a/packages/cli/src/helpers/log-compare-results.ts
+++ b/packages/cli/src/helpers/log-compare-results.ts
@@ -83,12 +83,15 @@ function outputSummaryReport(cli: Command, phaseResultsFormatted: HTMLSectionRen
     let msg = `${chalk.bold(phaseData.phase)} phase results are `;
 
     if (phaseData.isSignificant) {
+      let coloredDiff;
       if (phaseData.hlDiff > 0) {
         msg += `${chalk.black.bgRed(' SIGNIFICANT ')}`;
+        coloredDiff = chalk.red(`${phaseData.hlDiff}`);
       } else {
         msg += `${chalk.black.bgGreen(' SIGNIFICANT ')}`;
+        coloredDiff = chalk.green(`${phaseData.hlDiff}`);
       }
-      msg += ` with an estimated difference of ${phaseData.hlDiff}ms`;
+      msg += ` with an estimated difference of ${coloredDiff}ms`;
     } else {
       msg += `${chalk.black.bgWhite(' NOT SIGNIFICANT ')}`;
     }

--- a/packages/cli/src/helpers/log-compare-results.ts
+++ b/packages/cli/src/helpers/log-compare-results.ts
@@ -84,12 +84,12 @@ function outputSummaryReport(cli: Command, phaseResultsFormatted: HTMLSectionRen
 
     if (phaseData.isSignificant) {
       let coloredDiff;
-      if (phaseData.hlDiff > 0) {
+      if (phaseData.hlDiff < 0) {
         msg += `${chalk.black.bgRed(' SIGNIFICANT ')}`;
-        coloredDiff = chalk.red(`${phaseData.hlDiff}`);
+        coloredDiff = chalk.red(`+${Math.abs(phaseData.hlDiff)}`);
       } else {
         msg += `${chalk.black.bgGreen(' SIGNIFICANT ')}`;
-        coloredDiff = chalk.green(`${phaseData.hlDiff}`);
+        coloredDiff = chalk.green(`-${Math.abs(phaseData.hlDiff)}`);
       }
       msg += ` with an estimated difference of ${coloredDiff}ms`;
     } else {

--- a/packages/cli/src/helpers/log-compare-results.ts
+++ b/packages/cli/src/helpers/log-compare-results.ts
@@ -1,127 +1,156 @@
-import * as jsonQuery from 'json-query';
-import { IStatsOptions, Stats } from './statistics/stats';
+import chalk from 'chalk';
+
+import { Command } from '@oclif/command';
+import { bucketPhaseValues, formatPhaseData, HTMLSectionRenderData, ITracerBenchTraceResult, PAGE_LOAD_TIME } from './create-consumable-html';
+import { Stats } from './statistics/stats';
 import TBTable from './table';
 import { ICompareFlags } from '../commands/compare';
 import { fidelityLookup } from '../command-config/default-flag-args';
+import { chalkScheme } from './utils';
 
-const benchmarkTable = new TBTable('Initial Render');
-const phaseTable = new TBTable('Phase');
+/**
+ * If fidelity is at acceptable number, return true if any of the phase results were significant
+ *
+ * @param fidelity - Use this to determine if the sample count is too low
+ * @param benchmarkIsSigArray - Array of strings of either "Yes" or "No" from TBTable
+ * @param phaseIsSigArray - Array of strings of either "Yes" or "No" from TBTable
+ */
+function anyResultsSignificant(fidelity: number, benchmarkIsSigArray: string[], phaseIsSigArray: string[]): boolean {
+  // if fidelity !== 'test'
+  if (fidelity > fidelityLookup.test) {
+    return benchmarkIsSigArray.includes('Yes') || phaseIsSigArray.includes('Yes');
+  }
+  return false;
+}
 
-export function logCompareResults(
-  results: any,
-  flags: ICompareFlags,
-  cli: any
-) {
+function anyBelowRegressionThreshold(cliFlags: ICompareFlags, areResultsSignificant: boolean, benchmarkTable: TBTable, phaseTable: TBTable): boolean {
+  const { fidelity, regressionThreshold } = cliFlags;
+
+  if (fidelity >= fidelityLookup.low && regressionThreshold && areResultsSignificant) {
+    const deltas = benchmarkTable.estimatorDeltas.concat(phaseTable.estimatorDeltas);
+    return deltas.every(x => x > regressionThreshold);
+  }
+  return true;
+}
+
+const LOW_FIDELITY_WARNING = 'The fidelity setting was set below the recommended for a viable result. Rerun TracerBench with at least "fidelity=low"';
+
+/**
+ * Output meta data about the benchmark run and FYI messages to the user.
+ *
+ * @param cli - This is expected to be a "compare" Command instance
+ * @param cliFlags - This is expected to be CLI flags from the "compare" command
+ * @param isBelowRegressionThreshold - Boolean indicating if there were any deltas below "regressionThreshold" flag
+ */
+function outputRunMetaMessagesAndWarnings(cli: Command, cliFlags: ICompareFlags, isBelowRegressionThreshold: any) {
   const {
-    markers,
     fidelity,
-    json,
     tbResultsFolder,
     browserArgs,
     regressionThreshold,
-  } = flags;
+    report
+  } = cliFlags;
+  const browser = browserArgs.includes('--headless') ? 'Headless-Chrome' : 'Chrome';
+  // tslint:disable-next-line: max-line-length
+  let message = `${chalk.black.bgGreen(' Success! ')} ${fidelity} test samples were run with ${browser}. The JSON file with results from the compare test are available here: ${tbResultsFolder}/compare.json.`;
+  if (!report) {
+    message += `\nTo generate a pdf report run "tracerbench report --tbResultsFolder ${tbResultsFolder}"`;
+  }
+  cli.log(`\n${message}`);
 
-  // fn to get the marker data from tracerbench-results/compare.json
-  function getQueryData(id: string, marker?: any): IStatsOptions {
-    const query = !marker
-      ? `[samples][**][*${id}]`
-      : `[samples][**][${id}][*phase=${marker.label}].duration`;
-    const name = !marker ? id : marker.label;
-    return {
-      control: jsonQuery(`[*set=control]${query}`, {
-        data: results,
-      }).value,
-      experiment: jsonQuery(`[*set=experiment]${query}`, {
-        data: results,
-      }).value,
-      name,
-    };
+  if (fidelity < 10) {
+    cli.log(`\n${chalk.black.bgYellow(' WARNING ')} ${LOW_FIDELITY_WARNING}\n`);
   }
 
-  // duration === fetchStart
-  benchmarkTable.display.push(new Stats(getQueryData('duration')));
-  benchmarkTable.display.push(new Stats(getQueryData('js')));
+  if (!isBelowRegressionThreshold) {
+    cli.log(`A regression was found exceeding the set regression threshold of ${regressionThreshold}ms\n`);
+  }
+}
 
-  // iterate over the markers passed into the tbResultsFolder command
-  markers.forEach(marker => {
-    // get the marker data for each phase
-    const phase = getQueryData('phases', marker);
-    phaseTable.display.push(new Stats(phase));
+/**
+ * Generate the summary section for the results.
+ *
+ * For each phase, color the significance appropriately by the HL estimated difference. Red for regression, green for
+ * improvement. Color with monotone if not significant.
+ *
+ * @param cli - This is expected to be a "compare" Command instance
+ * @param phaseResultsFormatted - Array of results from calling formatPhaseData
+ */
+function outputSummaryReport(cli: Command, phaseResultsFormatted: HTMLSectionRenderData[]) {
+  cli.log(chalk.bgWhiteBright(chalkScheme.tbBranding.dkBlue('\n    =========== Benchmark Results Summary ===========    ')));
+  cli.log('Red color means there was a regression. Green color means there was an improvement. You can view more details about the phases above.\n');
+  phaseResultsFormatted.forEach((phaseData: HTMLSectionRenderData) => {
+    let msg = `${chalk.bold(phaseData.phase)} phase results are `;
+
+    if (phaseData.isSignificant) {
+      if (phaseData.hlDiff > 0) {
+        msg += `${chalk.black.bgRed(' SIGNIFICANT ')}`;
+      } else {
+        msg += `${chalk.black.bgGreen(' SIGNIFICANT ')}`;
+      }
+      msg += ` with an estimated difference of ${phaseData.hlDiff}ms`;
+    } else {
+      msg += `${chalk.black.bgWhite(' NOT SIGNIFICANT ')}`;
+    }
+
+    msg += '. \n';
+    cli.log(msg);
+  });
+}
+
+/**
+ * Collect and analyze the data for the different phases for the experiment and control set and output the result to the console.
+ *
+ * @param results - This is expected to be generated from tracerbench core's runner. Containing the dataset for experiment and control
+ * @param flags - This is expected to be CLI flags from the "compare" command
+ * @param cli - This is expected to be a "compare" Command instance
+ */
+export function logCompareResults(results: ITracerBenchTraceResult[], flags: ICompareFlags, cli: Command) {
+  const {
+    fidelity,
+  } = flags;
+  const benchmarkTable = new TBTable('Initial Render');
+  const phaseTable = new TBTable('Phase');
+
+  const controlData = results.find(element => {
+    return element.set === 'control';
+  }) as ITracerBenchTraceResult;
+
+  const experimentData = results.find(element => {
+    return element.set === 'experiment';
+  }) as ITracerBenchTraceResult;
+
+  const valuesByPhaseControl = bucketPhaseValues(controlData.samples);
+  const valuesByPhaseExperiment = bucketPhaseValues(experimentData.samples);
+
+  const subPhases = Object.keys(valuesByPhaseControl).filter((k) => k !== PAGE_LOAD_TIME);
+  const phaseResultsFormatted: HTMLSectionRenderData[] = [];
+
+  const durationStats = new Stats({
+    control: valuesByPhaseControl.duration,
+    experiment: valuesByPhaseExperiment.duration,
+    name: 'duration',
+  });
+  benchmarkTable.display.push(durationStats);
+  // @ts-ignore
+  phaseResultsFormatted.push(formatPhaseData(valuesByPhaseControl[PAGE_LOAD_TIME], valuesByPhaseExperiment[PAGE_LOAD_TIME], PAGE_LOAD_TIME));
+
+  subPhases.forEach(phase => {
+    phaseTable.display.push(new Stats({
+      control: valuesByPhaseControl[phase],
+      experiment: valuesByPhaseExperiment[phase],
+      name: phase,
+    }));
+    // @ts-ignore
+    phaseResultsFormatted.push(formatPhaseData(valuesByPhaseControl[phase], valuesByPhaseExperiment[phase], phase));
   });
 
-  const browser = browserArgs.includes('--headless')
-    ? 'Headless-Chrome'
-    : 'Chrome';
-  // tslint:disable-next-line: max-line-length
-  const message = `Success! ${fidelity} test samples were run with ${browser}. The JSON file with results from the compare test are available here: ${tbResultsFolder}/compare.json. To generate a pdf report run "tracerbench report"`;
-  const notSigMessage = `Wilcoxon rank-sum test indicated that there is NOT sufficient evidence that there is a statistical difference between the control and experiment.`;
-  // tslint:disable-next-line: max-line-length
-  const sigMessage = `Wilcoxon rank-sum test indicated that there IS sufficient evidence that there is a statistical difference between the control and experiment. We would expect 5% of these kinds of results to be due to chance with no underlying effect. A recommended "fidelity=high" compare test should be run to rule out false negatives.`;
-  const regThresholdMessage = `A regression was found exceeding the set regression threshold of ${regressionThreshold}ms`;
-  const lowFidelityMessage = `The fidelity setting was set below the recommended for a viable result. Rerun TracerBench with at least "fidelity=low"`;
-  const jsonResults = {
-    benchmarkTable: benchmarkTable.getData(),
-    phaseTable: phaseTable.getData(),
-    message,
-    isSignificant: isSignificant(),
-    isBelowRegressionThreshold: isBelowRegressionThreshold(),
-  };
+  const areResultsSignificant = anyResultsSignificant(fidelity, benchmarkTable.isSigArray, phaseTable.isSigArray);
+  const isBelowRegressionThreshold = anyBelowRegressionThreshold(flags, areResultsSignificant, benchmarkTable, phaseTable);
 
-  // if fidelity !== 'test'
-  function isSignificant(): boolean {
-    if (fidelity > fidelityLookup.test) {
-      return (
-        benchmarkTable.isSigArray.includes('Yes') ||
-        phaseTable.isSigArray.includes('Yes')
-      );
-    }
-    return false;
-  }
+  cli.log(`\n\n${benchmarkTable.render()}`);
+  cli.log(`\n\n${phaseTable.render()}`);
 
-  function isBelowRegressionThreshold(): boolean {
-    if (
-      fidelity >= fidelityLookup.low &&
-      regressionThreshold &&
-      isSignificant()
-    ) {
-      const deltas = benchmarkTable.estimatorDeltas.concat(
-        phaseTable.estimatorDeltas
-      );
-      return deltas.every(x => x > regressionThreshold);
-    }
-    return true;
-  }
-
-  if (jsonResults.isSignificant) {
-    jsonResults.message += ` ${sigMessage}`;
-  } else {
-    jsonResults.message += ` ${notSigMessage}`;
-  }
-  if (!jsonResults.isBelowRegressionThreshold) {
-    jsonResults.message += ` ${regThresholdMessage}`;
-  }
-  if (fidelity < 10) {
-    jsonResults.message += ` ${lowFidelityMessage}`;
-  }
-
-  if (!json) {
-    // LOG THE TABLES AND MESSAGE
-    cli.log(`\n\n${benchmarkTable.render()}`);
-    cli.log(`\n\n${phaseTable.render()}`);
-    cli.log(`\n${message}`);
-    if (jsonResults.isSignificant) {
-      cli.log(`\n${sigMessage}`);
-    } else {
-      cli.log(`\n${notSigMessage}`);
-    }
-    if (!jsonResults.isBelowRegressionThreshold) {
-      cli.log(`${regThresholdMessage}\n`);
-    }
-    if (fidelity < 10) {
-      cli.log(`\n${lowFidelityMessage}\n`);
-    }
-  } else {
-    // WILL ONLY STDOUT JSON. NO TABLES OR SPARKLINE
-    cli.log(JSON.stringify(jsonResults));
-  }
+  outputRunMetaMessagesAndWarnings(cli, flags, isBelowRegressionThreshold);
+  outputSummaryReport(cli, phaseResultsFormatted);
 }

--- a/packages/cli/src/helpers/log-compare-results.ts
+++ b/packages/cli/src/helpers/log-compare-results.ts
@@ -124,6 +124,4 @@ export function logCompareResults(
     // WILL ONLY STDOUT JSON. NO TABLES OR SPARKLINE
     cli.log(JSON.stringify(jsonResults));
   }
-  // RETURN JSON FOR ONLY FILE OUTPUT
-  return JSON.stringify(jsonResults);
 }

--- a/packages/cli/src/helpers/table.ts
+++ b/packages/cli/src/helpers/table.ts
@@ -78,9 +78,9 @@ export default class TBTable {
             colSpan: 1,
             content: 'Sample Counts:',
           },
-          `Control: ${stat.sampleCount.control}`,
+          `${chalkScheme.tbBranding.lime('Control')}: ${stat.sampleCount.control}`,
         ],
-        [`Experiment: ${stat.sampleCount.experiment}`],
+        [`${chalkScheme.tbBranding.aqua('Experiment')}: ${stat.sampleCount.experiment}`],
         [],
         [
           {

--- a/packages/cli/test/commands/compare.test.ts
+++ b/packages/cli/test/commands/compare.test.ts
@@ -67,7 +67,7 @@ describe('compare regression: fixture: A/B', () => {
           '--headless',
         ]);
 
-        chai.expect(ctx.stdout).to.contain(`that there IS sufficient`);
+        chai.expect(ctx.stdout).to.contain(`duration phase results are  SIGNIFICANT  `);
       }
     );
 });

--- a/packages/cli/test/commands/compare.test.ts
+++ b/packages/cli/test/commands/compare.test.ts
@@ -63,8 +63,7 @@ describe('compare regression: fixture: A/B', () => {
           regressionThreshold,
           '--tbResultsFolder',
           TB_RESULTS_FOLDER,
-          '--json',
-          '--headless',
+          '--headless'
         ]);
 
         chai.expect(ctx.stdout).to.contain(`duration phase results are  SIGNIFICANT  `);

--- a/packages/cli/test/commands/report.test.ts
+++ b/packages/cli/test/commands/report.test.ts
@@ -26,8 +26,7 @@ describe('report: creates html', () => {
           '--fidelity',
           fidelity,
           '--config',
-          TB_CONFIG_FILE,
-          '--json'
+          TB_CONFIG_FILE
         ]);
 
         await Report.run(['--tbResultsFolder', `${TB_RESULTS_FOLDER}`, '--config', `${TB_CONFIG_FILE}`]);

--- a/packages/cli/test/helpers/log-compare-results.test.ts
+++ b/packages/cli/test/helpers/log-compare-results.test.ts
@@ -41,9 +41,7 @@ const flags = {
 
 describe('log-compare-results', () => {
   test.stdout().it(`stdout`, ctx => {
-    const json = logCompareResults(results, flags, scope);
-    const pJSON = JSON.parse(json);
+    logCompareResults(results, flags, scope);
     expect(ctx.stdout).to.contain(`Success`);
-    expect(pJSON.message).to.contain(`Success`);
   });
 });

--- a/packages/cli/test/helpers/log-compare-results.test.ts
+++ b/packages/cli/test/helpers/log-compare-results.test.ts
@@ -5,16 +5,39 @@ import { test } from '@oclif/test';
 
 import * as path from 'path';
 
-const results = path.join(
-  `${process.cwd()}/test/fixtures/results/compare.json`
-);
-const markers = [
-  {
-    start: 'domComplete',
-    label: 'domComplete',
-  },
-];
-const tbResultsFolder = path.join(`${process.cwd()}/${tmpDir}`);
+const sampleTrace = {
+  'duration': 6260696,
+  'js': 5310439,
+  'phases': [
+    {
+      'phase': 'load',
+      'start': 0,
+      'duration': 1807839,
+    },
+    {
+      'phase': 'boot',
+      'start': 1807839,
+      'duration': 973172,
+    },
+    {
+      'phase': 'transition',
+      'start': 2781011,
+      'duration': 1540986,
+    },
+    {
+      'phase': 'render',
+      'start': 4321997,
+      'duration': 1905528,
+    },
+    {
+      'phase': 'paint',
+      'start': 6227525,
+      'duration': 33171,
+    },
+  ]
+};
+
+const tbResultsFolder = path.join(`${process.cwd()}/${tmpDir}/compare.json`);
 const scope = console;
 const network = {
   offline: false,
@@ -27,7 +50,6 @@ const flags = {
   browserArgs: [''],
   cpuThrottleRate: 2,
   fidelity: 2,
-  markers,
   network,
   tbResultsFolder,
   controlURL: '',
@@ -41,7 +63,16 @@ const flags = {
 
 describe('log-compare-results', () => {
   test.stdout().it(`stdout`, ctx => {
-    logCompareResults(results, flags, scope);
+    const testResults = [{
+      set: 'control',
+      samples: [sampleTrace, sampleTrace, sampleTrace, sampleTrace]
+    }, {
+      set: 'experiment',
+      samples: [sampleTrace, sampleTrace, sampleTrace, sampleTrace]
+    }];
+    // @ts-ignore
+    logCompareResults(testResults, flags, scope);
     expect(ctx.stdout).to.contain(`Success`);
+    expect(ctx.stdout).to.contain(`NOT SIGNIFICANT`);
   });
 });


### PR DESCRIPTION
The goal of these changes are to provide a similar experience as the pdf artifact but in the terminal output.

I refactored logCompareResults to use the same functions that createConsumeableHTML uses to prepare its data. I left the original tables intact but made some changes to the summary at the bottom.

- Removed the "js" section
- Removed the JSON dump of the results generated from logCompareResults

Original
![Screen Shot 2019-08-11 at 5 14 13 PM](https://user-images.githubusercontent.com/2080348/62841312-815e5680-bc5b-11e9-8c5e-270b6e088407.png)


Sample when phases are insignificant
![Screen Shot 2019-08-11 at 4 17 31 PM](https://user-images.githubusercontent.com/2080348/62841245-88d13000-bc5a-11e9-9bf1-2863ad313c45.png)

Sample when phases are significant
![Screen Shot 2019-08-11 at 5 10 37 PM](https://user-images.githubusercontent.com/2080348/62841268-f8471f80-bc5a-11e9-8d6a-7123d03442a1.png)