### PR TITLE
fix: fixing compare cmd to include json return

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,7 +24,7 @@ $ npm install -g tracerbench
 $ tracerbench COMMAND
 running command...
 $ tracerbench (-v|--version|version)
-tracerbench/2.1.0 darwin-x64 node-v10.16.0
+tracerbench/2.1.0 darwin-x64 node-v10.16.3
 $ tracerbench --help [COMMAND]
 USAGE
   $ tracerbench COMMAND

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "jstat": "^1.9.0",
     "log-symbols": "^3.0.0",
     "path": "0.12.7",
-    "tslib": "^1.9.3"
+    "tslib": "^1.10.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.0",
@@ -54,11 +54,11 @@
     "mock-fs": "^4.10.1",
     "nyc": "^14.1.1",
     "prettier": "^1.16.4",
-    "ts-node": "^8.0.3",
-    "tslint": "^5.14.0",
+    "ts-node": "^8.4.1",
+    "tslint": "^5.20.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.3.4000",
+    "typescript": "^3.6.3",
     "typescript-json-schema": "^0.37.0"
   },
   "engines": {

--- a/packages/cli/src/command-config/tb-config.ts
+++ b/packages/cli/src/command-config/tb-config.ts
@@ -36,7 +36,6 @@ export interface ITBConfig {
   regressionThreshold?: number | string;
   servers?: [IHARServer, IHARServer];
   headless?: boolean;
-  json?: boolean;
   debug?: boolean;
   // Optional overrides specific to control or experiment benchmark environments
   [CONTROL_ENV_OVERRIDE_ATTR]?: IBenchmarkEnvironmentOverride;

--- a/packages/cli/src/commands/compare/analyze.ts
+++ b/packages/cli/src/commands/compare/analyze.ts
@@ -1,23 +1,22 @@
 import { Command } from '@oclif/command';
 import { logCompareResults } from '../../helpers/log-compare-results';
 import * as fs from 'fs-extra';
-import {
-  fidelity, tbResultsFolder
-} from '../../helpers/flags';
+import { fidelity, tbResultsFolder } from '../../helpers/flags';
 
 export default class CompareAnalyze extends Command {
-  public static description = 'Run an analysis of a benchmark run from a results json file and output to terminal';
+  public static description =
+    'Run an analysis of a benchmark run from a results json file and output to terminal';
   public static args = [
-    { name: 'resultsFile', required: true, description: 'Results JSON file' }
+    { name: 'resultsFile', required: true, description: 'Results JSON file' },
   ];
   public static flags = {
     fidelity: fidelity({ required: true }),
-    tbResultsFolder: tbResultsFolder({ required: true })
+    tbResultsFolder: tbResultsFolder({ required: true }),
   };
-  
-  public async run() {
+
+  public async run(): Promise<string> {
     const { args, flags } = this.parse(CompareAnalyze);
     const results = fs.readJsonSync(args.resultsFile);
-    logCompareResults(results, flags, this);
+    return logCompareResults(results, flags, this);
   }
 }

--- a/packages/cli/src/helpers/create-consumable-html.ts
+++ b/packages/cli/src/helpers/create-consumable-html.ts
@@ -42,7 +42,7 @@ export interface HTMLSectionRenderData {
 }
 
 interface ValuesByPhase {
- [key: string]: number[]
+  [key: string]: number[];
 }
 
 export const PAGE_LOAD_TIME = 'duration';
@@ -50,22 +50,31 @@ export const PAGE_LOAD_TIME = 'duration';
 const CHART_CSS_PATH = path.join(__dirname, '../static/chart-bootstrap.css');
 const CHART_JS_PATH = path.join(
   __dirname,
-  '../static/chartjs-2.8.0-chart.min.js',
+  '../static/chartjs-2.8.0-chart.min.js'
 );
 const REPORT_PATH = path.join(__dirname, '../static/report-template.hbs');
-const PHASE_DETAIL_PARTIAL = path.join(__dirname, '../static/phase-detail-partial.hbs');
-const PHASE_CHART_JS_PARTIAL = path.join(__dirname, '../static/phase-chart-js-partial.hbs');
+const PHASE_DETAIL_PARTIAL = path.join(
+  __dirname,
+  '../static/phase-detail-partial.hbs'
+);
+const PHASE_CHART_JS_PARTIAL = path.join(
+  __dirname,
+  '../static/phase-chart-js-partial.hbs'
+);
 
 const CHART_CSS = readFileSync(CHART_CSS_PATH, 'utf8');
 const CHART_JS = readFileSync(CHART_JS_PATH, 'utf8');
 const PHASE_DETAIL_TEMPLATE_RAW = readFileSync(PHASE_DETAIL_PARTIAL, 'utf8');
-const PHASE_CHART_JS_TEMPLATE_RAW = readFileSync(PHASE_CHART_JS_PARTIAL, 'utf8');
+const PHASE_CHART_JS_TEMPLATE_RAW = readFileSync(
+  PHASE_CHART_JS_PARTIAL,
+  'utf8'
+);
 let REPORT_TEMPLATE_RAW = readFileSync(REPORT_PATH, 'utf8');
 
 REPORT_TEMPLATE_RAW = REPORT_TEMPLATE_RAW.toString()
   .replace(
     '{{!-- TRACERBENCH-CHART-BOOTSTRAP.CSS --}}',
-    `<style>${CHART_CSS}</style>`,
+    `<style>${CHART_CSS}</style>`
   )
   .replace('{{!-- TRACERBENCH-CHART-JS --}}', `<script>${CHART_JS}</script>`);
 
@@ -101,14 +110,16 @@ Handlebars.registerHelper('absSort', (num1, num2, position) => {
   return sorted[position];
 });
 
-
 /**
  * Extract the phases and page load time latency into sorted buckets by phase
  *
  * @param samples - Array of "sample" objects
  * @param valueGen - Calls this function to extract the value from the phase. A "phase" is passed containing duration and start
  */
-export function bucketPhaseValues(samples: Sample[], valueGen: any = (a: any) => a.duration): ValuesByPhase {
+export function bucketPhaseValues(
+  samples: Sample[],
+  valueGen: any = (a: any) => a.duration
+): ValuesByPhase {
   const buckets: { [key: string]: number[] } = { [PAGE_LOAD_TIME]: [] };
 
   samples.forEach((sample: Sample) => {
@@ -142,9 +153,9 @@ export function resolveTitles(tbConfig: Partial<ITBConfig>) {
     reportTitles.servers = tbConfig.servers as any;
     reportTitles.servers = reportTitles.servers.map((titleConfig, idx) => {
       if (idx === 0) {
-        return {name: `Control: ${titleConfig.name}`};
+        return { name: `Control: ${titleConfig.name}` };
       } else {
-        return {name: `Experiment: ${titleConfig.name}`};
+        return { name: `Experiment: ${titleConfig.name}` };
       }
     }) as any;
   }
@@ -162,16 +173,28 @@ export function resolveTitles(tbConfig: Partial<ITBConfig>) {
  * @param controlData - Samples of the benchmark of control server
  * @param experimentData - Samples of the benchmark experiment server
  */
-export function buildCumulativeChartData(controlData: ITracerBenchTraceResult, experimentData: ITracerBenchTraceResult) {
-  const cumulativeValueFunc = (a: any) => convertMicrosecondsToMS(a.start + a.duration);
-  const valuesByPhaseControl = bucketPhaseValues(controlData.samples, cumulativeValueFunc);
-  const valuesByPhaseExperiment = bucketPhaseValues(experimentData.samples, cumulativeValueFunc);
-  const phases = Object.keys(valuesByPhaseControl).filter((k) => k !== PAGE_LOAD_TIME);
+export function buildCumulativeChartData(
+  controlData: ITracerBenchTraceResult,
+  experimentData: ITracerBenchTraceResult
+) {
+  const cumulativeValueFunc = (a: any) =>
+    convertMicrosecondsToMS(a.start + a.duration);
+  const valuesByPhaseControl = bucketPhaseValues(
+    controlData.samples,
+    cumulativeValueFunc
+  );
+  const valuesByPhaseExperiment = bucketPhaseValues(
+    experimentData.samples,
+    cumulativeValueFunc
+  );
+  const phases = Object.keys(valuesByPhaseControl).filter(
+    k => k !== PAGE_LOAD_TIME
+  );
 
   return {
     categories: JSON.stringify(phases),
-    controlData: JSON.stringify(phases.map((k) => valuesByPhaseControl[k])),
-    experimentData: JSON.stringify(phases.map((k) => valuesByPhaseExperiment[k])),
+    controlData: JSON.stringify(phases.map(k => valuesByPhaseControl[k])),
+    experimentData: JSON.stringify(phases.map(k => valuesByPhaseExperiment[k])),
   };
 }
 
@@ -183,7 +206,11 @@ export function buildCumulativeChartData(controlData: ITracerBenchTraceResult, e
  * @param experimentValues - Values for the experiment for the phase
  * @param phaseName - Name of the phase the values represent
  */
-export function formatPhaseData(controlValues: number[], experimentValues: number[], phaseName: string): Partial<HTMLSectionRenderData> {
+export function formatPhaseData(
+  controlValues: number[],
+  experimentValues: number[],
+  phaseName: string
+): HTMLSectionRenderData {
   const stats = new Stats({
     control: controlValues,
     experiment: experimentValues,
@@ -199,19 +226,27 @@ export function formatPhaseData(controlValues: number[], experimentValues: numbe
     identifierHash: phaseName,
     isSignificant: !isNotSignificant,
     // Ensure to convert to milliseconds for presentation
-    controlSamples: JSON.stringify(controlValues.map((val) => convertMicrosecondsToMS(val))),
-    experimentSamples: JSON.stringify(experimentValues.map((val) => convertMicrosecondsToMS(val))),
+    controlSamples: JSON.stringify(
+      controlValues.map(val => convertMicrosecondsToMS(val))
+    ),
+    experimentSamples: JSON.stringify(
+      experimentValues.map(val => convertMicrosecondsToMS(val))
+    ),
     sampleCount: controlValues.length,
     ciMin: stats.confidenceInterval.min,
     ciMax: stats.confidenceInterval.max,
-    hlDiff: stats.estimator
+    hlDiff: stats.estimator,
+    servers: undefined,
   };
 }
 
 /**
  * Prioritize the phase that has the largest difference in regression first.
  */
-export function phaseSorter(a: HTMLSectionRenderData, b: HTMLSectionRenderData): number {
+export function phaseSorter(
+  a: HTMLSectionRenderData,
+  b: HTMLSectionRenderData
+): number {
   const A_ON_TOP = -1;
   const B_ON_TOP = 1;
 
@@ -236,21 +271,31 @@ export function phaseSorter(a: HTMLSectionRenderData, b: HTMLSectionRenderData):
 export default function createConsumeableHTML(
   controlData: ITracerBenchTraceResult,
   experimentData: ITracerBenchTraceResult,
-  tbConfig: ITBConfig,
+  tbConfig: ITBConfig
 ): string {
   const valuesByPhaseControl = bucketPhaseValues(controlData.samples);
   const valuesByPhaseExperiment = bucketPhaseValues(experimentData.samples);
-  const subPhases = Object.keys(valuesByPhaseControl).filter((k) => k !== PAGE_LOAD_TIME);
+  const subPhases = Object.keys(valuesByPhaseControl).filter(
+    k => k !== PAGE_LOAD_TIME
+  );
   const subPhaseSections: HTMLSectionRenderData[] = [];
   const reportTitles = resolveTitles(tbConfig);
-  const durationSection = formatPhaseData(valuesByPhaseControl[PAGE_LOAD_TIME], valuesByPhaseExperiment[PAGE_LOAD_TIME], PAGE_LOAD_TIME);
+  const durationSection = formatPhaseData(
+    valuesByPhaseControl[PAGE_LOAD_TIME],
+    valuesByPhaseExperiment[PAGE_LOAD_TIME],
+    PAGE_LOAD_TIME
+  );
 
   durationSection.servers = reportTitles.servers;
 
   subPhases.forEach(phase => {
     const controlValues = valuesByPhaseControl[phase];
     const experimentValues = valuesByPhaseExperiment[phase];
-    const renderDataForPhase = formatPhaseData(controlValues, experimentValues, phase);
+    const renderDataForPhase = formatPhaseData(
+      controlValues,
+      experimentValues,
+      phase
+    );
     renderDataForPhase.servers = reportTitles.servers;
     subPhaseSections.push(renderDataForPhase as HTMLSectionRenderData);
   });
@@ -265,6 +310,6 @@ export default function createConsumeableHTML(
     reportTitles,
     subPhaseSections,
     configsSJSONString: JSON.stringify(tbConfig, null, 4),
-    sectionFormattedDataJson: JSON.stringify(subPhaseSections)
+    sectionFormattedDataJson: JSON.stringify(subPhaseSections),
   });
 }

--- a/packages/cli/src/helpers/log-compare-results.ts
+++ b/packages/cli/src/helpers/log-compare-results.ts
@@ -1,12 +1,37 @@
 import chalk from 'chalk';
 
 import { Command } from '@oclif/command';
-import { bucketPhaseValues, formatPhaseData, HTMLSectionRenderData, ITracerBenchTraceResult, PAGE_LOAD_TIME } from './create-consumable-html';
-import { Stats } from './statistics/stats';
+import {
+  bucketPhaseValues,
+  formatPhaseData,
+  HTMLSectionRenderData,
+  ITracerBenchTraceResult,
+  PAGE_LOAD_TIME,
+} from './create-consumable-html';
+import { Stats, ISevenFigureSummary } from './statistics/stats';
 import TBTable from './table';
 import { ICompareFlags } from '../commands/compare';
 import { fidelityLookup } from '../command-config';
 import { chalkScheme } from './utils';
+
+export interface ICompareJSONResult {
+  heading: string;
+  phaseName: string;
+  isSignificant: 'Yes' | 'No';
+  estimatorDelta: string;
+  controlSampleCount: number;
+  experimentSampleCount: number;
+  confidenceInterval: string[];
+  controlSevenFigureSummary: ISevenFigureSummary;
+  experimentSevenFigureSummary: ISevenFigureSummary;
+}
+
+export interface ICompareJSONResults {
+  benchmarkTableData: ICompareJSONResult[];
+  phaseTableData: ICompareJSONResult[];
+  areResultsSignificant: boolean;
+  isBelowRegressionThreshold: boolean;
+}
 
 /**
  * If fidelity is at acceptable number, return true if any of the phase results were significant
@@ -15,25 +40,46 @@ import { chalkScheme } from './utils';
  * @param benchmarkIsSigArray - Array of strings of either "Yes" or "No" from TBTable
  * @param phaseIsSigArray - Array of strings of either "Yes" or "No" from TBTable
  */
-function anyResultsSignificant(fidelity: number, benchmarkIsSigArray: string[], phaseIsSigArray: string[]): boolean {
+export function anyResultsSignificant(
+  fidelity: number,
+  benchmarkIsSigArray: string[],
+  phaseIsSigArray: string[]
+): boolean {
   // if fidelity !== 'test'
   if (fidelity > fidelityLookup.test) {
-    return benchmarkIsSigArray.includes('Yes') || phaseIsSigArray.includes('Yes');
+    console.log(benchmarkIsSigArray);
+    console.log(phaseIsSigArray);
+
+    return (
+      benchmarkIsSigArray.includes('Yes') || phaseIsSigArray.includes('Yes')
+    );
   }
   return false;
 }
 
-function anyBelowRegressionThreshold(cliFlags: Partial<ICompareFlags>, areResultsSignificant: boolean, benchmarkTable: TBTable, phaseTable: TBTable): boolean {
+export function anyBelowRegressionThreshold(
+  cliFlags: Partial<ICompareFlags>,
+  areResultsSignificant: boolean,
+  benchmarkTable: TBTable,
+  phaseTable: TBTable
+): boolean {
   const { fidelity, regressionThreshold } = cliFlags;
 
-  if (fidelity as number >= fidelityLookup.low && regressionThreshold && areResultsSignificant) {
-    const deltas = benchmarkTable.estimatorDeltas.concat(phaseTable.estimatorDeltas);
+  if (
+    (fidelity as number) >= fidelityLookup.low &&
+    regressionThreshold &&
+    areResultsSignificant
+  ) {
+    const deltas = benchmarkTable.estimatorDeltas.concat(
+      phaseTable.estimatorDeltas
+    );
     return deltas.every(x => x > regressionThreshold);
   }
   return true;
 }
 
-const LOW_FIDELITY_WARNING = 'The fidelity setting was set below the recommended for a viable result. Rerun TracerBench with at least "fidelity=low"';
+const LOW_FIDELITY_WARNING =
+  'The fidelity setting was set below the recommended for a viable result. Rerun TracerBench with at least "fidelity=low"';
 
 /**
  * Output meta data about the benchmark run and FYI messages to the user.
@@ -42,17 +88,20 @@ const LOW_FIDELITY_WARNING = 'The fidelity setting was set below the recommended
  * @param cliFlags - This is expected to be CLI flags from the "compare" command
  * @param isBelowRegressionThreshold - Boolean indicating if there were any deltas below "regressionThreshold" flag
  */
-function outputRunMetaMessagesAndWarnings(cli: Command, cliFlags: Partial<ICompareFlags>, isBelowRegressionThreshold: any) {
-  const {
-    fidelity,
-    regressionThreshold
-  } = cliFlags;
+export function outputRunMetaMessagesAndWarnings(
+  cli: Command,
+  cliFlags: Partial<ICompareFlags>,
+  isBelowRegressionThreshold: any
+) {
+  const { fidelity, regressionThreshold } = cliFlags;
   if ((fidelity as number) < 10) {
     cli.log(`\n${chalk.black.bgYellow(' WARNING ')} ${LOW_FIDELITY_WARNING}\n`);
   }
 
   if (!isBelowRegressionThreshold) {
-    cli.log(`A regression was found exceeding the set regression threshold of ${regressionThreshold}ms\n`);
+    cli.log(
+      `A regression was found exceeding the set regression threshold of ${regressionThreshold}ms\n`
+    );
   }
 }
 
@@ -65,21 +114,37 @@ function outputRunMetaMessagesAndWarnings(cli: Command, cliFlags: Partial<ICompa
  * @param cli - This is expected to be a "compare" Command instance
  * @param phaseResultsFormatted - Array of results from calling formatPhaseData
  */
-function outputSummaryReport(cli: Command, phaseResultsFormatted: HTMLSectionRenderData[]) {
-  cli.log(chalk.bgWhiteBright(chalkScheme.tbBranding.dkBlue('\n    =========== Benchmark Results Summary ===========    ')));
-  cli.log(`${chalk.red('Red')} color means there was a regression. ${chalk.green('Green')} color means there was an improvement. You can view more statistical details about the phases above.\n`);
-  phaseResultsFormatted.forEach((phaseData: HTMLSectionRenderData) => {
-    let msg = `${chalk.bold(phaseData.phase)} phase has `;
+export function outputSummaryReport(
+  cli: Command,
+  phaseResultsFormatted: Array<
+    Pick<HTMLSectionRenderData, 'phase' | 'hlDiff' | 'isSignificant'>
+  >
+) {
+  cli.log(
+    chalk.bgWhiteBright(
+      chalkScheme.tbBranding.dkBlue(
+        '\n    =========== Benchmark Results Summary ===========    '
+      )
+    )
+  );
+  cli.log(
+    `${chalk.red('Red')} color means there was a regression. ${chalk.green(
+      'Green'
+    )} color means there was an improvement. You can view more statistical details about the phases above.\n`
+  );
+  phaseResultsFormatted.forEach(phaseData => {
+    const { phase, hlDiff, isSignificant } = phaseData;
+    let msg = `${chalk.bold(phase)} phase has `;
 
-    if (phaseData.isSignificant) {
+    if (isSignificant) {
       let coloredDiff;
 
       msg += 'an estimated difference of ';
 
-      if (phaseData.hlDiff < 0) {
-        coloredDiff = chalk.red(`+${Math.abs(phaseData.hlDiff)}ms`);
+      if (hlDiff < 0) {
+        coloredDiff = chalk.red(`+${Math.abs(hlDiff)}ms`);
       } else {
-        coloredDiff = chalk.green(`-${Math.abs(phaseData.hlDiff)}ms`);
+        coloredDiff = chalk.green(`-${Math.abs(hlDiff)}ms`);
       }
 
       msg += `${coloredDiff}`;
@@ -93,18 +158,47 @@ function outputSummaryReport(cli: Command, phaseResultsFormatted: HTMLSectionRen
 }
 
 /**
+ * Return the trimmed compare results in JSON format
+ *
+ * This is propogated as the default return all the way up to the Compare command directly
+ * without the need for the legacy --json flag
+ *
+ * @param benchmarkTableData - ICompareJSONResult[] from instantiated TBTable#getData() for the top level duration
+ * @param phaseTableData - ICompareJSONResult[] from instantiated TBTable#getData() for all sub phases of the top level duration
+ * @param areResultsSignificant - A culled boolean if any results are significant this is truthy
+ * @param isBelowRegressionThreshold - A culled boolean to check if all results are below the config regression threshold
+ * @return jsonResults - A JSON.stringified return of the trimmed compare results
+ */
+export function outputJSONResults(
+  benchmarkTableData: ICompareJSONResult[],
+  phaseTableData: ICompareJSONResult[],
+  areResultsSignificant: boolean,
+  isBelowRegressionThreshold: boolean
+): string {
+  const jsonResults: ICompareJSONResults = {
+    benchmarkTableData,
+    phaseTableData,
+    areResultsSignificant,
+    isBelowRegressionThreshold,
+  };
+  return JSON.stringify(jsonResults);
+}
+
+/**
  * Collect and analyze the data for the different phases for the experiment and control set and output the result to the console.
  *
  * @param results - This is expected to be generated from tracerbench core's runner. Containing the dataset for experiment and control
  * @param flags - This is expected to be CLI flags from the "compare" command
  * @param cli - This is expected to be a "compare" Command instance
  */
-export function logCompareResults(results: ITracerBenchTraceResult[], flags: Partial<ICompareFlags>, cli: Command) {
-  const {
-    fidelity,
-  } = flags;
+export function logCompareResults(
+  results: ITracerBenchTraceResult[],
+  flags: Partial<ICompareFlags>,
+  cli: Command
+): string {
+  const { fidelity } = flags;
   const benchmarkTable = new TBTable('Initial Render');
-  const phaseTable = new TBTable('Phase');
+  const phaseTable = new TBTable('Sub Phase of Duration');
 
   const controlData = results.find(element => {
     return element.set === 'control';
@@ -117,8 +211,12 @@ export function logCompareResults(results: ITracerBenchTraceResult[], flags: Par
   const valuesByPhaseControl = bucketPhaseValues(controlData.samples);
   const valuesByPhaseExperiment = bucketPhaseValues(experimentData.samples);
 
-  const subPhases = Object.keys(valuesByPhaseControl).filter((k) => k !== PAGE_LOAD_TIME);
-  const phaseResultsFormatted: HTMLSectionRenderData[] = [];
+  const subPhases = Object.keys(valuesByPhaseControl).filter(
+    k => k !== PAGE_LOAD_TIME
+  );
+  const phaseResultsFormatted: Array<
+    Pick<HTMLSectionRenderData, 'phase' | 'hlDiff' | 'isSignificant'>
+  > = [];
 
   const durationStats = new Stats({
     control: valuesByPhaseControl.duration,
@@ -127,24 +225,55 @@ export function logCompareResults(results: ITracerBenchTraceResult[], flags: Par
   });
   benchmarkTable.display.push(durationStats);
   // @ts-ignore
-  phaseResultsFormatted.push(formatPhaseData(valuesByPhaseControl[PAGE_LOAD_TIME], valuesByPhaseExperiment[PAGE_LOAD_TIME], PAGE_LOAD_TIME));
+  phaseResultsFormatted.push(
+    formatPhaseData(
+      valuesByPhaseControl[PAGE_LOAD_TIME],
+      valuesByPhaseExperiment[PAGE_LOAD_TIME],
+      PAGE_LOAD_TIME
+    )
+  );
 
   subPhases.forEach(phase => {
-    phaseTable.display.push(new Stats({
-      control: valuesByPhaseControl[phase],
-      experiment: valuesByPhaseExperiment[phase],
-      name: phase,
-    }));
+    phaseTable.display.push(
+      new Stats({
+        control: valuesByPhaseControl[phase],
+        experiment: valuesByPhaseExperiment[phase],
+        name: phase,
+      })
+    );
     // @ts-ignore
-    phaseResultsFormatted.push(formatPhaseData(valuesByPhaseControl[phase], valuesByPhaseExperiment[phase], phase));
+    phaseResultsFormatted.push(
+      formatPhaseData(
+        valuesByPhaseControl[phase],
+        valuesByPhaseExperiment[phase],
+        phase
+      )
+    );
   });
 
-  const areResultsSignificant = anyResultsSignificant(fidelity as number, benchmarkTable.isSigArray, phaseTable.isSigArray);
-  const isBelowRegressionThreshold = anyBelowRegressionThreshold(flags, areResultsSignificant, benchmarkTable, phaseTable);
+  const benchmarkTableData = benchmarkTable.getData();
+  const phaseTableData = phaseTable.getData();
+  const areResultsSignificant = anyResultsSignificant(
+    fidelity as number,
+    benchmarkTable.isSigArray,
+    phaseTable.isSigArray
+  );
+  const isBelowRegressionThreshold = anyBelowRegressionThreshold(
+    flags,
+    areResultsSignificant,
+    benchmarkTable,
+    phaseTable
+  );
 
   cli.log(`\n\n${benchmarkTable.render()}`);
   cli.log(`\n\n${phaseTable.render()}`);
 
   outputRunMetaMessagesAndWarnings(cli, flags, isBelowRegressionThreshold);
   outputSummaryReport(cli, phaseResultsFormatted);
+  return outputJSONResults(
+    benchmarkTableData,
+    phaseTableData,
+    areResultsSignificant,
+    isBelowRegressionThreshold
+  );
 }

--- a/packages/cli/src/helpers/table.ts
+++ b/packages/cli/src/helpers/table.ts
@@ -1,22 +1,9 @@
 import chalk from 'chalk';
 
 import * as Table from 'cli-table3';
-import { Stats, ISevenFigureSummary } from './statistics/stats';
+import { Stats } from './statistics/stats';
 import { chalkScheme } from './utils';
-
-export interface ICompareJSONResults {
-  heading: string;
-  statName: string;
-  isSignificant: 'Yes' | 'No';
-  estimatorDelta: string;
-  controlSampleCount: number;
-  experimentSampleCount: number;
-  confidenceIntervalMin: string;
-  confidenceIntervalMax: string;
-  confidenceIntervalIsSig: 'Yes' | 'No' | string;
-  controlSevenFigureSummary: ISevenFigureSummary;
-  experimentSevenFigureSummary: ISevenFigureSummary;
-}
+import { ICompareJSONResult } from './log-compare-results';
 
 export default class TBTable {
   public config: Table.TableConstructorOptions;
@@ -35,20 +22,21 @@ export default class TBTable {
     this.estimatorDeltas = [];
   }
 
-  // return table data for --json flag
-  public getData(): ICompareJSONResults[] {
-    const a: ICompareJSONResults[] = [];
+  // return table data for JSON results
+  public getData(): ICompareJSONResult[] {
+    const a: ICompareJSONResult[] = [];
     this.display.forEach(stat => {
       a.push({
         heading: this.heading,
-        statName: stat.name,
+        phaseName: stat.name,
         isSignificant: stat.confidenceInterval.isSig,
         estimatorDelta: `${stat.estimator}ms`,
         controlSampleCount: stat.sampleCount.control,
         experimentSampleCount: stat.sampleCount.experiment,
-        confidenceIntervalMin: `${stat.confidenceInterval.min}ms`,
-        confidenceIntervalMax: `${stat.confidenceInterval.max}ms`,
-        confidenceIntervalIsSig: `${stat.confidenceInterval.isSig}`,
+        confidenceInterval: [
+          `${stat.confidenceInterval.min}ms`,
+          `${stat.confidenceInterval.max}ms`,
+        ],
         controlSevenFigureSummary: stat.sevenFigureSummary.control,
         experimentSevenFigureSummary: stat.sevenFigureSummary.experiment,
       });
@@ -71,7 +59,6 @@ export default class TBTable {
       const estimatorForDisplay = stat.estimator * -1;
       let hlDeltaWithColor;
 
-
       if (stat.confidenceInterval.isSig === 'Yes') {
         if (estimatorForDisplay > 0) {
           hlDeltaWithColor = chalk.red(`${estimatorForDisplay}ms`);
@@ -87,7 +74,7 @@ export default class TBTable {
           {
             colSpan: 2,
             content: `${chalkScheme.tbBranding.blue(
-              `${this.heading} : ${stat.name}`,
+              `${this.heading} : ${stat.name}`
             )}`,
           },
         ],
@@ -148,7 +135,8 @@ export default class TBTable {
           },
           {
             // For display flip the min and max
-            content: `${stat.confidenceInterval.max * -1}ms to ${stat.confidenceInterval.min * -1}ms`,
+            content: `${stat.confidenceInterval.max * -1}ms to ${stat
+              .confidenceInterval.min * -1}ms`,
           },
         ],
         [],
@@ -163,7 +151,7 @@ export default class TBTable {
           {
             content: `${stat.sparkLine.experiment}`,
           },
-        ],
+        ]
       );
     });
   }

--- a/packages/cli/tb-schema.json
+++ b/packages/cli/tb-schema.json
@@ -146,9 +146,6 @@
                 "number"
             ]
         },
-        "json": {
-            "type": "boolean"
-        },
         "locations": {
             "type": "string"
         },

--- a/packages/cli/test/commands/compare.test.ts
+++ b/packages/cli/test/commands/compare.test.ts
@@ -1,8 +1,9 @@
 import { test } from '@oclif/test';
-import * as chai from 'chai';
+import { expect } from 'chai';
 import Compare from '../../src/commands/compare';
 import { defaultFlagArgs } from '../../src/command-config';
 import { FIXTURE_APP, TB_RESULTS_FOLDER } from '../test-helpers';
+import { ICompareJSONResults } from '../../src/helpers/log-compare-results';
 
 const fidelity = 'test';
 const emulateDevice = 'iphone-4';
@@ -30,16 +31,16 @@ describe('compare fixture: A/A', () => {
           '--debug',
         ]);
 
-        chai.expect(ctx.stdout).to.contain(`Success`);
-        chai
-          .expect(`${TB_RESULTS_FOLDER}/server-control-settings.json`)
-          .to.be.a.file();
-        chai
-          .expect(`${TB_RESULTS_FOLDER}/server-experiment-settings.json`)
-          .to.be.a.file();
-        chai
-          .expect(`${TB_RESULTS_FOLDER}/compare-flags-settings.json`)
-          .to.be.a.file();
+        expect(ctx.stdout).to.contain(`Success`);
+        expect(
+          `${TB_RESULTS_FOLDER}/server-control-settings.json`
+        ).to.be.a.file();
+        expect(
+          `${TB_RESULTS_FOLDER}/server-experiment-settings.json`
+        ).to.be.a.file();
+        expect(
+          `${TB_RESULTS_FOLDER}/compare-flags-settings.json`
+        ).to.be.a.file();
       }
     );
 });
@@ -52,7 +53,7 @@ describe('compare regression: fixture: A/B', () => {
         defaultFlagArgs.tracingLocationSearch} --experimentURL ${FIXTURE_APP.regression +
         defaultFlagArgs.tracingLocationSearch} --fidelity=low --tbResultsFolder ${TB_RESULTS_FOLDER} --regressionThreshold ${regressionThreshold} --cpuThrottleRate=1 --headless`,
       async ctx => {
-        await Compare.run([
+        const results = await Compare.run([
           '--controlURL',
           FIXTURE_APP.control,
           '--experimentURL',
@@ -63,10 +64,16 @@ describe('compare regression: fixture: A/B', () => {
           regressionThreshold,
           '--tbResultsFolder',
           TB_RESULTS_FOLDER,
-          '--headless'
+          '--headless',
         ]);
 
-        chai.expect(ctx.stdout).to.contain(`duration phase has an estimated difference of`);
+        const resultsJSON: ICompareJSONResults = JSON.parse(results);
+
+        expect(ctx.stdout).to.contain(
+          `duration phase has an estimated difference of`
+        );
+        // tslint:disable-next-line: no-unused-expression
+        expect(resultsJSON.areResultsSignificant).to.be.true;
       }
     );
 });
@@ -94,7 +101,7 @@ describe('compare mobile horizontal: fixture: A/A', () => {
           '--headless',
         ]);
 
-        chai.expect(ctx.stdout).to.contain(`Success`);
+        expect(ctx.stdout).to.contain(`Success`);
       }
     );
 });
@@ -122,7 +129,7 @@ describe('compare mobile vertical: fixture: A/A', () => {
           '--headless',
         ]);
 
-        chai.expect(ctx.stdout).to.contain(`Success`);
+        expect(ctx.stdout).to.contain(`Success`);
       }
     );
 });
@@ -150,7 +157,7 @@ describe('compare mobile vertical: fixture: A/A', () => {
           '--headless',
         ]);
 
-        chai.expect(ctx.stdout).to.contain(`Success`);
+        expect(ctx.stdout).to.contain(`Success`);
       }
     );
 });

--- a/packages/cli/test/commands/report.test.ts
+++ b/packages/cli/test/commands/report.test.ts
@@ -1,10 +1,12 @@
 import { test } from '@oclif/test';
-import * as chai from 'chai';
+import { expect } from 'chai';
 import Compare from '../../src/commands/compare';
 import Report from '../../src/commands/report';
-import { FIXTURE_APP, TB_RESULTS_FOLDER, TB_CONFIG_FILE } from '../test-helpers';
-
-chai.use(require('chai-fs'));
+import {
+  FIXTURE_APP,
+  TB_RESULTS_FOLDER,
+  TB_CONFIG_FILE,
+} from '../test-helpers';
 
 const fidelity = 'test';
 
@@ -12,7 +14,7 @@ describe('report: creates html', () => {
   test
     .stdout()
     .it(
-      `runs report --inputFilePath ${TB_RESULTS_FOLDER}/compare.json --tbResultsFolder ${TB_RESULTS_FOLDER} --headless --fidelity ${fidelity} --config ${TB_CONFIG_FILE} --json`,
+      `runs report --inputFilePath ${TB_RESULTS_FOLDER}/compare.json --tbResultsFolder ${TB_RESULTS_FOLDER} --headless --fidelity ${fidelity} --config ${TB_CONFIG_FILE}`,
       async ctx => {
         await Compare.run([
           '--controlURL',
@@ -26,14 +28,21 @@ describe('report: creates html', () => {
           '--fidelity',
           fidelity,
           '--config',
-          TB_CONFIG_FILE
+          TB_CONFIG_FILE,
         ]);
 
-        await Report.run(['--tbResultsFolder', `${TB_RESULTS_FOLDER}`, '--config', `${TB_CONFIG_FILE}`]);
+        await Report.run([
+          '--tbResultsFolder',
+          `${TB_RESULTS_FOLDER}`,
+          '--config',
+          `${TB_CONFIG_FILE}`,
+        ]);
 
-        chai.expect(ctx.stdout).to.contain(`The PDF and HTML reports are available here`);
-        chai.expect(`${TB_RESULTS_FOLDER}/artifact-1.html`).to.be.a.file();
-        chai.expect(`${TB_RESULTS_FOLDER}/artifact-1.pdf`).to.be.a.file();
+        expect(ctx.stdout).to.contain(
+          `The PDF and HTML reports are available here`
+        );
+        expect(`${TB_RESULTS_FOLDER}/artifact-1.html`).to.be.a.file();
+        expect(`${TB_RESULTS_FOLDER}/artifact-1.pdf`).to.be.a.file();
       }
     );
 });

--- a/packages/cli/test/helpers/log-compare-results.test.ts
+++ b/packages/cli/test/helpers/log-compare-results.test.ts
@@ -1,4 +1,7 @@
-import { logCompareResults } from '../../src/helpers/log-compare-results';
+import {
+  logCompareResults,
+  ICompareJSONResults,
+} from '../../src/helpers/log-compare-results';
 import { expect } from 'chai';
 import { tmpDir } from '../setup';
 import { test } from '@oclif/test';
@@ -6,35 +9,35 @@ import { test } from '@oclif/test';
 import * as path from 'path';
 
 const sampleTrace = {
-  'duration': 6260696,
-  'js': 5310439,
-  'phases': [
+  duration: 6260696,
+  js: 5310439,
+  phases: [
     {
-      'phase': 'load',
-      'start': 0,
-      'duration': 1807839,
+      phase: 'load',
+      start: 0,
+      duration: 1807839,
     },
     {
-      'phase': 'boot',
-      'start': 1807839,
-      'duration': 973172,
+      phase: 'boot',
+      start: 1807839,
+      duration: 973172,
     },
     {
-      'phase': 'transition',
-      'start': 2781011,
-      'duration': 1540986,
+      phase: 'transition',
+      start: 2781011,
+      duration: 1540986,
     },
     {
-      'phase': 'render',
-      'start': 4321997,
-      'duration': 1905528,
+      phase: 'render',
+      start: 4321997,
+      duration: 1905528,
     },
     {
-      'phase': 'paint',
-      'start': 6227525,
-      'duration': 33171,
+      phase: 'paint',
+      start: 6227525,
+      duration: 33171,
     },
-  ]
+  ],
 };
 
 const tbResultsFolder = path.join(`${process.cwd()}/${tmpDir}/compare.json`);
@@ -56,22 +59,33 @@ const flags = {
   experimentURL: '',
   tracingLocationSearch: '',
   runtimeStats: false,
-  json: false,
   debug: false,
   headless: false,
 };
 
+const jsonResults = {
+  areResultsSignificant: false,
+  benchmarkTableData: [{}],
+  isBelowRegressionThreshold: true,
+  phaseTableData: [{}],
+};
+
 describe('log-compare-results', () => {
   test.stdout().it(`stdout`, ctx => {
-    const testResults = [{
-      set: 'control',
-      samples: [sampleTrace, sampleTrace, sampleTrace, sampleTrace]
-    }, {
-      set: 'experiment',
-      samples: [sampleTrace, sampleTrace, sampleTrace, sampleTrace]
-    }];
+    const testResults = [
+      {
+        set: 'control',
+        samples: [sampleTrace, sampleTrace, sampleTrace, sampleTrace],
+      },
+      {
+        set: 'experiment',
+        samples: [sampleTrace, sampleTrace, sampleTrace, sampleTrace],
+      },
+    ];
     // @ts-ignore
-    logCompareResults(testResults, flags, scope);
+    const results = logCompareResults(testResults, flags, scope);
+    const resultsJSON: ICompareJSONResults = JSON.parse(results);
     expect(ctx.stdout).to.contain(`has no difference`);
+    expect(resultsJSON).to.have.all.keys(jsonResults);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6394,12 +6394,23 @@ ts-node@^8.0.3:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
+ts-node@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.4.1.tgz#270b0dba16e8723c9fa4f9b4775d3810fd994b4f"
+  integrity sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
+
 tslib@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
   integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
@@ -6462,6 +6473,25 @@ tslint@^5.14.0:
     chalk "^2.3.0"
     commander "^2.12.1"
     diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.29.0"
+
+tslint@^5.20.0:
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.0.tgz#fac93bfa79568a5a24e7be9cdde5e02b02d00ec1"
+  integrity sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^4.0.1"
     glob "^7.1.1"
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
@@ -6543,6 +6573,11 @@ typescript@^3.0.1, typescript@^3.3.4000, typescript@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
   integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+
+typescript@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
This PR address the existing bug with the compare command --json flag. Additionally includes dep bumps and additional tests.

Additionally this PR allows for the compare command to return JSON as the default without the need to explicitly include the `--json` flag