### PR TITLE
feat(cli): tracerbench base cmd

### DIFF
--- a/packages/cli/src/command-config/index.ts
+++ b/packages/cli/src/command-config/index.ts
@@ -1,3 +1,5 @@
+import TBBaseCommand, { flags } from './tb-base';
+
 export { ITBConfig, INetworkConditions, IHARServer } from './tb-config';
 export {
   fidelityLookup,
@@ -7,3 +9,4 @@ export {
   getDefaultValue,
 } from './default-flag-args';
 export { getConfig } from './build-config';
+export { TBBaseCommand, flags };

--- a/packages/cli/src/command-config/tb-base.ts
+++ b/packages/cli/src/command-config/tb-base.ts
@@ -1,0 +1,13 @@
+import { Command } from '@oclif/command';
+import { IConfig } from '@oclif/config';
+
+export { flags } from '@oclif/command';
+
+export default abstract class TBBaseCommand extends Command {
+  constructor(argv: string[], config: IConfig) {
+    super(argv, config);
+  }
+  public async init() {
+    //
+  }
+}

--- a/packages/cli/src/commands/compare/analyze.ts
+++ b/packages/cli/src/commands/compare/analyze.ts
@@ -1,9 +1,9 @@
-import { Command } from '@oclif/command';
+import { TBBaseCommand } from '../../command-config';
 import { logCompareResults } from '../../helpers/log-compare-results';
-import * as fs from 'fs-extra';
+import { readJsonSync } from 'fs-extra';
 import { fidelity, tbResultsFolder } from '../../helpers/flags';
 
-export default class CompareAnalyze extends Command {
+export default class CompareAnalyze extends TBBaseCommand {
   public static description =
     'Run an analysis of a benchmark run from a results json file and output to terminal';
   public static args = [
@@ -16,7 +16,7 @@ export default class CompareAnalyze extends Command {
 
   public async run(): Promise<string> {
     const { args, flags } = this.parse(CompareAnalyze);
-    const results = fs.readJsonSync(args.resultsFile);
-    return logCompareResults(results, flags, this);
+    const results = readJsonSync(args.resultsFile);
+    return await logCompareResults(results, flags, this);
   }
 }

--- a/packages/cli/src/commands/compare/index.ts
+++ b/packages/cli/src/commands/compare/index.ts
@@ -1,7 +1,7 @@
 import Protocol from 'devtools-protocol';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { Command, flags } from '@oclif/command';
+import { TBBaseCommand, flags, getConfig } from '../../command-config';
 import {
   IInitialRenderBenchmarkParams,
   InitialRenderBenchmark,
@@ -46,7 +46,6 @@ import {
   ITBConfig,
 } from '../../command-config/tb-config';
 import { IConfig } from '@oclif/config';
-import { getConfig } from '../../command-config';
 import CompareAnalyze from './analyze';
 import Report from '../report';
 
@@ -72,7 +71,7 @@ export interface ICompareFlags {
   report?: boolean;
 }
 
-export default class Compare extends Command {
+export default class Compare extends TBBaseCommand {
   public static description =
     'Compare the performance delta between an experiment and control';
   public static flags = {

--- a/packages/cli/src/commands/create-archive.ts
+++ b/packages/cli/src/commands/create-archive.ts
@@ -1,15 +1,15 @@
-import { Command } from '@oclif/command';
+import { TBBaseCommand } from '../command-config';
 import { harTrace } from '@tracerbench/core';
 import { browserArgs, tbResultsFolder, url } from '../helpers/flags';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 
-export default class CreateArchive extends Command {
+export default class CreateArchive extends TBBaseCommand {
   public static description = 'Creates an automated HAR file from a URL.';
   public static flags = {
     browserArgs: browserArgs({ required: true }),
     tbResultsFolder: tbResultsFolder({ required: true }),
-    url: url({ required: true })
+    url: url({ required: true }),
   };
 
   public async run() {
@@ -28,7 +28,9 @@ export default class CreateArchive extends Command {
     fs.writeFileSync(cookiesJSON, JSON.stringify(cookies));
     fs.writeFileSync(archiveOutput, JSON.stringify(harArchive));
 
-    this.log(`Captured ${harArchive.log.entries.length} request responses in har file.`);
+    this.log(
+      `Captured ${harArchive.log.entries.length} request responses in har file.`
+    );
     return this.log(
       `HAR & cookies.json successfully generated from ${url} and available here: ${archiveOutput} and ${cookiesJSON}`
     );

--- a/packages/cli/src/commands/marker-timings.ts
+++ b/packages/cli/src/commands/marker-timings.ts
@@ -1,4 +1,4 @@
-import { Command } from '@oclif/command';
+import { TBBaseCommand } from '../command-config';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { ITraceEvent } from '@tracerbench/core';
@@ -16,7 +16,7 @@ import {
   loadTraceFile,
 } from '../helpers/utils';
 
-export default class MarkerTimings extends Command {
+export default class MarkerTimings extends TBBaseCommand {
   public static description = 'Get list of all user-timings from trace';
 
   public static flags = {

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -1,9 +1,13 @@
 import * as fs from 'fs-extra';
 import { join, resolve } from 'path';
 
-import { Command } from '@oclif/command';
 import { IConfig } from '@oclif/config';
-import { ITBConfig, defaultFlagArgs, getConfig } from '../command-config';
+import {
+  ITBConfig,
+  defaultFlagArgs,
+  getConfig,
+  TBBaseCommand,
+} from '../command-config';
 import createConsumeableHTML, {
   ITracerBenchTraceResult,
 } from '../helpers/create-consumable-html';
@@ -18,7 +22,7 @@ export interface IReportFlags {
   config?: string;
 }
 
-export default class Report extends Command {
+export default class Report extends TBBaseCommand {
   public static description = `Parses the output json from tracerbench and formats it into pdf and html`;
   public static flags = {
     tbResultsFolder: tbResultsFolder({ required: true }),
@@ -107,7 +111,11 @@ export default class Report extends Command {
     await printToPDF(`file://${absPathToHTML}`, absOutputPath);
 
     this.log(
-      `The PDF and HTML reports are available here: ${chalkScheme.tbBranding.lime.underline.bold(absPathToHTML)} and here: ${chalkScheme.tbBranding.blue.underline.bold(absOutputPath)}\n`
+      `The PDF and HTML reports are available here: ${chalkScheme.tbBranding.lime.underline.bold(
+        absPathToHTML
+      )} and here: ${chalkScheme.tbBranding.blue.underline.bold(
+        absOutputPath
+      )}\n`
     );
   }
   private async parseFlags() {

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -1,4 +1,4 @@
-import { Command } from '@oclif/command';
+import { TBBaseCommand } from '../command-config';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import {
@@ -24,7 +24,7 @@ import {
   loadTraceFile,
 } from '../helpers/utils';
 
-export default class Trace extends Command {
+export default class Trace extends TBBaseCommand {
   public static description = `Parses a CPU profile and aggregates time across heuristics. Can optinally be vertically sliced with event names.`;
   public static flags = {
     cpuThrottleRate: cpuThrottleRate({ required: true }),
@@ -33,7 +33,7 @@ export default class Trace extends Command {
     url: url({ required: true }),
     iterations: iterations({ required: true }),
     locations: locations(),
-    insights
+    insights,
   };
 
   public async run() {

--- a/packages/cli/src/helpers/log-compare-results.ts
+++ b/packages/cli/src/helpers/log-compare-results.ts
@@ -180,11 +180,11 @@ export function outputJSONResults(
  * @param flags - This is expected to be CLI flags from the "compare" command
  * @param cli - This is expected to be a "compare" Command instance
  */
-export function logCompareResults(
+export async function logCompareResults(
   results: ITracerBenchTraceResult[],
   flags: Pick<ICompareFlags, 'fidelity'>,
   cli: Command
-): string {
+): Promise<string> {
   const { fidelity } = flags;
   const benchmarkTable = new TBTable('Initial Render');
   const phaseTable = new TBTable('Sub Phase of Duration');

--- a/packages/cli/test/helpers/log-compare-results.test.ts
+++ b/packages/cli/test/helpers/log-compare-results.test.ts
@@ -73,7 +73,7 @@ const jsonResults = {
 };
 
 describe('log-compare-results', () => {
-  test.stdout().it(`stdout`, ctx => {
+  test.stdout().it(`stdout`, async ctx => {
     const testResults = [
       {
         set: 'control',
@@ -85,7 +85,7 @@ describe('log-compare-results', () => {
       },
     ];
     // @ts-ignore
-    const results = logCompareResults(testResults, flags, scope);
+    const results = await logCompareResults(testResults, flags, scope);
     const resultsJSON: ICompareJSONResults = JSON.parse(results);
     expect(ctx.stdout).to.contain(`has no difference`);
     expect(resultsJSON).to.have.all.keys(jsonResults);


### PR DESCRIPTION
This PR will set us up to refactor redundant setup code within each command into a single base command which is then extended for children commands. 

Additionally this will set us up to succinctly implement `pre-req()` checks centralized without redundancy.  