### PR TITLE
feat: collect garbage between samples

### DIFF
--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -4,7 +4,7 @@ import {
   withRaceTimeout
 } from 'race-cancellation';
 
-declare let gc: () => void;
+import gc from './util/gc';
 
 const SETUP_TIMEOUT = 2000;
 const SAMPLE_TIMEOUT = 15 * 1000;
@@ -109,9 +109,7 @@ async function takeSamples<TSample>(
         group,
         i
       );
-      if (typeof gc === 'function') {
-        gc();
-      }
+      gc();
       const sampler = samplers[group];
       const sample = await sampleWithTimeout(
         sampler,

--- a/packages/core/src/util/gc.ts
+++ b/packages/core/src/util/gc.ts
@@ -1,0 +1,6 @@
+import { setFlagsFromString } from 'v8';
+import { runInNewContext } from 'vm';
+
+setFlagsFromString('--expose-gc');
+const gc: () => void = runInNewContext('gc');
+export default gc;


### PR DESCRIPTION
Dynamically get the gc function so that a user doesn't need to set --expose-gc since this is hard to do with the CLI.
