### PR TITLE
feat: add pValue and zScore

### DIFF
--- a/packages/cli/test/compare/generate-stats.test.ts
+++ b/packages/cli/test/compare/generate-stats.test.ts
@@ -43,10 +43,10 @@ describe("generate-stats", () => {
     expect(durationSection.stats.sampleCount.control).to.eql(20);
     expect(durationSection.stats.sampleCount.experiment).to.eql(20);
     // duration 95% confidence-interval
-    expect(durationSection.stats.confidenceInterval.min).to.eql(-1002);
+    expect(durationSection.stats.confidenceInterval.min).to.eql(-1001);
     expect(durationSection.stats.confidenceInterval.max).to.eql(-997);
     expect(durationSection.stats.confidenceInterval.isSig).to.be.true;
-    expect(durationSection.stats.confidenceIntervals[95].min).to.eql(-1002);
+    expect(durationSection.stats.confidenceIntervals[95].min).to.eql(-1001);
     expect(durationSection.stats.confidenceIntervals[95].max).to.eql(-997);
     expect(durationSection.stats.confidenceIntervals[95].isSig).to.be.true;
     // duration 99% confidence-interval
@@ -77,7 +77,7 @@ describe("generate-stats", () => {
     // duration sample count
     expect(durationSection.sampleCount).to.eq(20);
     // duration confidence interval min
-    expect(durationSection.ciMin).to.eq(-1002);
+    expect(durationSection.ciMin).to.eq(-1001);
     // duration confidence interval max
     expect(durationSection.ciMax).to.eq(-997);
     // duration estimator

--- a/packages/stats/src/stats.ts
+++ b/packages/stats/src/stats.ts
@@ -215,14 +215,14 @@ export class Stats {
   ): IConfidenceInterval {
     const ci = confidenceInterval(control, experiment, confidenceLevel);
     const isSig =
-      (ci[0] < 0 && 0 < ci[1]) ||
-      (ci[0] > 0 && 0 > ci[1]) ||
-      (ci[0] === 0 && ci[1] === 0)
+      (ci.lower < 0 && 0 < ci.upper) ||
+      (ci.lower > 0 && 0 > ci.upper) ||
+      (ci.lower === 0 && ci.upper === 0)
         ? false
         : true;
     return {
-      min: Math.round(Math.ceil(ci[0] * 100) / 100),
-      max: Math.round(Math.ceil(ci[1] * 100) / 100),
+      min: Math.round(Math.ceil(ci.lower * 100) / 100),
+      max: Math.round(Math.ceil(ci.upper * 100) / 100),
       isSig
     };
   }

--- a/packages/stats/test/confidence-interval.test.ts
+++ b/packages/stats/test/confidence-interval.test.ts
@@ -51,9 +51,11 @@ const experiment = [
 ];
 
 describe('confidence-interval test', () => {
+  // lower -17.598544903204015
   it(`confidenceInterval()`, () => {
-    expect(confidenceInterval(control, experiment, 0.95)).to.eqls([
-      -17.598544903204015,
+    const ci = confidenceInterval(control, experiment, 0.95);
+    expect([ci.lower, ci.upper]).to.eqls([
+      -16.645916059851004,
       50.779366826444004
     ]);
   });

--- a/packages/stats/tsconfig.json
+++ b/packages/stats/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "module": "commonjs",
     "resolveJsonModule": true,
-    "target": "es2017",
+    "target": "es2019",
     "outDir": "./dist"
   },
   "include": ["src"],

--- a/packages/stats/types/jstat/index.d.ts
+++ b/packages/stats/types/jstat/index.d.ts
@@ -2,6 +2,7 @@ declare module 'jstat' {
   const jStat: {
     normal: {
       inv(p: number, mean: number, std: number): number;
+      cdf(q: number, mean: number, std: number): number;
     };
   };
   export = jStat;


### PR DESCRIPTION
Add pValue and zScore and unify test in preparation for adding quality rating to test result to aid in determining how borderline evidence is.