### PR TITLE
feat(stats): opt unitConverterFn in Stat constructor

### DIFF
--- a/packages/cli/src/compare/generate-stats.ts
+++ b/packages/cli/src/compare/generate-stats.ts
@@ -1,4 +1,8 @@
-import { convertMicrosecondsToMS, Stats } from "@tracerbench/stats";
+import {
+  convertMicrosecondsToMS,
+  roundTenthsAndConvertMicrosecondsToMS,
+  Stats,
+} from "@tracerbench/stats";
 
 import { md5sum } from "../helpers/utils";
 
@@ -187,11 +191,15 @@ export class GenerateStats {
     experimentValues: number[],
     phaseName: string
   ): HTMLSectionRenderData {
-    const stats = new Stats({
-      control: controlValues,
-      experiment: experimentValues,
-      name: phaseName,
-    });
+    // all stats will be converted to milliseconds and rounded to tenths
+    const stats = new Stats(
+      {
+        control: controlValues,
+        experiment: experimentValues,
+        name: phaseName,
+      },
+      roundTenthsAndConvertMicrosecondsToMS
+    );
 
     const estimatorIsSig = Math.abs(stats.estimator) >= 1 ? true : false;
     const frequency: Frequency = {
@@ -224,7 +232,7 @@ export class GenerateStats {
         q3: stats.sevenFigureSummary.control[75],
         max: stats.sevenFigureSummary.control.max,
         outliers: stats.outliers.control.outliers,
-        samplesMS: stats.controlMS,
+        samplesMS: stats.control,
       },
       experimentFormatedSamples: {
         min: stats.sevenFigureSummary.experiment.min,
@@ -233,7 +241,7 @@ export class GenerateStats {
         q3: stats.sevenFigureSummary.experiment[75],
         max: stats.sevenFigureSummary.experiment.max,
         outliers: stats.outliers.experiment.outliers,
-        samplesMS: stats.experimentMS,
+        samplesMS: stats.experiment,
       },
     };
   }

--- a/packages/cli/src/compare/generate-stats.ts
+++ b/packages/cli/src/compare/generate-stats.ts
@@ -1,6 +1,6 @@
 import {
   convertMicrosecondsToMS,
-  roundTenthsAndConvertMicrosecondsToMS,
+  roundFloatAndConvertMicrosecondsToMS,
   Stats,
 } from "@tracerbench/stats";
 
@@ -198,7 +198,7 @@ export class GenerateStats {
         experiment: experimentValues,
         name: phaseName,
       },
-      roundTenthsAndConvertMicrosecondsToMS
+      roundFloatAndConvertMicrosecondsToMS
     );
 
     const estimatorIsSig = Math.abs(stats.estimator) >= 1 ? true : false;

--- a/packages/cli/src/compare/tb-table.ts
+++ b/packages/cli/src/compare/tb-table.ts
@@ -1,4 +1,4 @@
-import { Stats } from "@tracerbench/stats";
+import type { Stats } from "@tracerbench/stats";
 import * as chalk from "chalk";
 import * as Table from "cli-table3";
 

--- a/packages/cli/test/compare/generate-stats.test.ts
+++ b/packages/cli/test/compare/generate-stats.test.ts
@@ -26,17 +26,17 @@ describe("generate-stats", () => {
     } = durationSection;
     // STATS
     // duration control in ms and not sorted
-    expect(durationSection.stats.controlMS[0]).to.eql(434);
-    expect(durationSection.stats.controlMS[19]).to.eql(305);
+    expect(durationSection.stats.control[0]).to.eql(305);
+    expect(durationSection.stats.control[19]).to.eql(434);
     // duration experiment in ms and not sorted
-    expect(durationSection.stats.experimentMS[0]).to.eql(1309);
-    expect(durationSection.stats.experimentMS[19]).to.eql(1309);
+    expect(durationSection.stats.experiment[0]).to.eql(1299);
+    expect(durationSection.stats.experiment[19]).to.eql(1328);
     // duration control in ms and sorted
-    expect(durationSection.stats.controlSortedMS[0]).to.eql(305);
-    expect(durationSection.stats.controlSortedMS[19]).to.eql(434);
+    expect(durationSection.stats.controlSorted[0]).to.eql(305);
+    expect(durationSection.stats.controlSorted[19]).to.eql(434);
     // duration experiment in ms and sorted
-    expect(durationSection.stats.experimentSortedMS[0]).to.eql(1299);
-    expect(durationSection.stats.experimentSortedMS[19]).to.eql(1328);
+    expect(durationSection.stats.experimentSorted[0]).to.eql(1299);
+    expect(durationSection.stats.experimentSorted[19]).to.eql(1328);
     // duration name
     expect(durationSection.stats.name).to.eql("duration");
     // sample count
@@ -44,10 +44,10 @@ describe("generate-stats", () => {
     expect(durationSection.stats.sampleCount.experiment).to.eql(20);
     // duration 95% confidence-interval
     expect(durationSection.stats.confidenceInterval.min).to.eql(-1001);
-    expect(durationSection.stats.confidenceInterval.max).to.eql(-997);
+    expect(durationSection.stats.confidenceInterval.max).to.eql(-996);
     expect(durationSection.stats.confidenceInterval.isSig).to.be.true;
     expect(durationSection.stats.confidenceIntervals[95].min).to.eql(-1001);
-    expect(durationSection.stats.confidenceIntervals[95].max).to.eql(-997);
+    expect(durationSection.stats.confidenceIntervals[95].max).to.eql(-996);
     expect(durationSection.stats.confidenceIntervals[95].isSig).to.be.true;
     // duration 99% confidence-interval
     expect(durationSection.stats.confidenceIntervals[99].min).to.eql(-1002);
@@ -56,21 +56,21 @@ describe("generate-stats", () => {
     // duration estimator
     expect(durationSection.stats.estimator).to.eql(-999);
     // duration control outliers
-    expect(durationSection.stats.outliers.control.outliers.length).to.eq(2);
-    expect(durationSection.stats.outliers.control.outliers[0]).to.eq(338);
-    expect(durationSection.stats.outliers.control.outliers[1]).to.eq(434);
-    expect(durationSection.stats.outliers.control.lowerOutlier).to.eq(303);
-    expect(durationSection.stats.outliers.control.upperOutlier).to.eq(316);
+    expect(durationSection.stats.outliers.control.outliers.length).to.eq(3);
+    expect(durationSection.stats.outliers.control.outliers[0]).to.eq(315);
+    expect(durationSection.stats.outliers.control.outliers[1]).to.eq(338);
+    expect(durationSection.stats.outliers.control.lowerOutlier).to.eq(304);
+    expect(durationSection.stats.outliers.control.upperOutlier).to.eq(314);
     // duration experiment outliers
     expect(durationSection.stats.outliers.experiment.outliers.length).to.eq(4);
     expect(durationSection.stats.outliers.experiment.outliers[0]).to.eq(1299);
     expect(durationSection.stats.outliers.experiment.outliers[1]).to.eq(1320);
     expect(durationSection.stats.outliers.experiment.outliers[2]).to.eq(1325);
     expect(durationSection.stats.outliers.experiment.outliers[3]).to.eq(1328);
-    expect(durationSection.stats.outliers.experiment.lowerOutlier).to.eq(1301);
-    expect(durationSection.stats.outliers.experiment.upperOutlier).to.eq(1317);
+    expect(durationSection.stats.outliers.experiment.lowerOutlier).to.eq(1300);
+    expect(durationSection.stats.outliers.experiment.upperOutlier).to.eq(1318);
     // duration interquartile range
-    expect(durationSection.stats.outliers.control.IQR).to.eq(3);
+    expect(durationSection.stats.outliers.control.IQR).to.eq(2);
     expect(durationSection.stats.outliers.experiment.IQR).to.eq(4);
     // duration is significant
     expect(durationSection.isSignificant).to.be.true;
@@ -79,7 +79,7 @@ describe("generate-stats", () => {
     // duration confidence interval min
     expect(durationSection.ciMin).to.eq(-1001);
     // duration confidence interval max
-    expect(durationSection.ciMax).to.eq(-997);
+    expect(durationSection.ciMax).to.eq(-996);
     // duration estimator
     expect(durationSection.hlDiff).to.eq(-999);
     // duration control formatted samples
@@ -88,11 +88,11 @@ describe("generate-stats", () => {
     expect(controlFormatedSamples.median).to.eq(309);
     expect(controlFormatedSamples.q3).to.eq(311);
     expect(controlFormatedSamples.max).to.eq(434);
-    expect(controlFormatedSamples.outliers.length).to.eq(2);
-    expect(controlFormatedSamples.outliers[0]).to.eq(338);
-    expect(controlFormatedSamples.outliers[1]).to.eq(434);
-    expect(controlFormatedSamples.samplesMS[0]).to.eq(434);
-    expect(controlFormatedSamples.samplesMS[19]).to.eq(305);
+    expect(controlFormatedSamples.outliers.length).to.eq(3);
+    expect(controlFormatedSamples.outliers[0]).to.eq(315);
+    expect(controlFormatedSamples.outliers[1]).to.eq(338);
+    expect(controlFormatedSamples.samplesMS[0]).to.eq(305);
+    expect(controlFormatedSamples.samplesMS[19]).to.eq(434);
     // duration experiment formatted samples
     expect(experimentFormatedSamples.min).to.eq(1299);
     expect(experimentFormatedSamples.q1).to.eq(1307);
@@ -104,9 +104,9 @@ describe("generate-stats", () => {
     expect(experimentFormatedSamples.outliers[1]).to.eq(1320);
     expect(experimentFormatedSamples.outliers[2]).to.eq(1325);
     expect(experimentFormatedSamples.outliers[3]).to.eq(1328);
-    expect(experimentFormatedSamples.samplesMS[0]).to.eq(1309);
-    expect(experimentFormatedSamples.samplesMS[3]).to.eq(1304);
-    expect(experimentFormatedSamples.samplesMS[19]).to.eq(1309);
+    expect(experimentFormatedSamples.samplesMS[0]).to.eq(1299);
+    expect(experimentFormatedSamples.samplesMS[3]).to.eq(1305);
+    expect(experimentFormatedSamples.samplesMS[19]).to.eq(1328);
   });
 
   it(`generateData() subPhaseSections`, () => {
@@ -117,17 +117,17 @@ describe("generate-stats", () => {
     // subphase
     expect(subPhaseSections.length).to.eql(7);
     // render control in ms and not sorted
-    expect(renderPhase.stats.controlMS[0]).to.eql(20);
-    expect(renderPhase.stats.controlMS[19]).to.eql(20);
+    expect(renderPhase.stats.control[0]).to.eql(20);
+    expect(renderPhase.stats.control[19]).to.eql(29);
     // render experiment in ms and not sorted
-    expect(renderPhase.stats.experimentMS[0]).to.eql(20);
-    expect(renderPhase.stats.experimentMS[19]).to.eql(21);
+    expect(renderPhase.stats.experiment[0]).to.eql(20);
+    expect(renderPhase.stats.experiment[19]).to.eql(23);
     // render control in ms and sorted
-    expect(renderPhase.stats.controlSortedMS[0]).to.eql(20);
-    expect(renderPhase.stats.controlSortedMS[19]).to.eql(29);
+    expect(renderPhase.stats.controlSorted[0]).to.eql(20);
+    expect(renderPhase.stats.controlSorted[19]).to.eql(29);
     // render experiment in ms and sorted
-    expect(renderPhase.stats.experimentSortedMS[0]).to.eql(20);
-    expect(renderPhase.stats.experimentSortedMS[19]).to.eql(23);
+    expect(renderPhase.stats.experimentSorted[0]).to.eql(20);
+    expect(renderPhase.stats.experimentSorted[19]).to.eql(23);
     // render estimator
     expect(renderPhase.stats.estimator).to.eql(0);
     // phase name
@@ -148,20 +148,20 @@ describe("generate-stats", () => {
     expect(controlFormatedSamples.median).to.eq(20);
     expect(controlFormatedSamples.q3).to.eq(21);
     expect(controlFormatedSamples.max).to.eq(29);
-    expect(controlFormatedSamples.outliers.length).to.eq(1);
-    expect(controlFormatedSamples.outliers[0]).to.eq(29);
+    expect(controlFormatedSamples.outliers.length).to.eq(2);
+    expect(controlFormatedSamples.outliers[0]).to.eq(23);
     expect(controlFormatedSamples.samplesMS[0]).to.eq(20);
-    expect(controlFormatedSamples.samplesMS[19]).to.eq(20);
+    expect(controlFormatedSamples.samplesMS[19]).to.eq(29);
     // render experiment formatted samples
     expect(experimentFormatedSamples.min).to.eq(20);
     expect(experimentFormatedSamples.q1).to.eq(20);
     expect(experimentFormatedSamples.median).to.eq(20);
     expect(experimentFormatedSamples.q3).to.eq(21);
     expect(experimentFormatedSamples.max).to.eq(23);
-    expect(experimentFormatedSamples.outliers.length).to.eq(0);
+    expect(experimentFormatedSamples.outliers.length).to.eq(2);
     expect(experimentFormatedSamples.samplesMS[0]).to.eq(20);
-    expect(experimentFormatedSamples.samplesMS[12]).to.eq(23);
-    expect(experimentFormatedSamples.samplesMS[19]).to.eq(21);
+    expect(experimentFormatedSamples.samplesMS[12]).to.eq(20);
+    expect(experimentFormatedSamples.samplesMS[19]).to.eq(23);
   });
 
   it(`bucketCumulative() cumulativeData`, () => {

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -9,7 +9,7 @@ import {
 import {
   convertMicrosecondsToMS,
   convertMSToMicroseconds,
-  roundTenthsAndConvertMicrosecondsToMS,
+  roundFloatAndConvertMicrosecondsToMS,
   toNearestHundreth
 } from './utils';
 import { getWilcoxonRankSumTest } from './wilcoxon-rank-sum';
@@ -28,5 +28,5 @@ export {
   IOutliers,
   IStatsOptions,
   IConfidenceInterval,
-  roundTenthsAndConvertMicrosecondsToMS
+  roundFloatAndConvertMicrosecondsToMS
 };

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   convertMicrosecondsToMS,
   convertMSToMicroseconds,
+  roundTenthsAndConvertMicrosecondsToMS,
   toNearestHundreth
 } from './utils';
 import { getWilcoxonRankSumTest } from './wilcoxon-rank-sum';
@@ -26,5 +27,6 @@ export {
   ISevenFigureSummary,
   IOutliers,
   IStatsOptions,
-  IConfidenceInterval
+  IConfidenceInterval,
+  roundTenthsAndConvertMicrosecondsToMS
 };

--- a/packages/stats/src/utils.ts
+++ b/packages/stats/src/utils.ts
@@ -12,6 +12,14 @@ export function toNearestHundreth(n: number): number {
   return Math.round(n * 100) / 100;
 }
 
+export function roundTenthsAndConvertMicrosecondsToMS(
+  ms: string | number
+): number {
+  ms = typeof ms === 'string' ? parseInt(ms, 10) : ms;
+  ms = Math.floor(ms * 100) / 100000;
+  return Math.round(ms * 10) / 10;
+}
+
 export function fillArray(arrLngth: number, incr = 1, strt = 0): number[] {
   const a = [];
   while (a.length < arrLngth) {

--- a/packages/stats/src/utils.ts
+++ b/packages/stats/src/utils.ts
@@ -12,12 +12,12 @@ export function toNearestHundreth(n: number): number {
   return Math.round(n * 100) / 100;
 }
 
-export function roundTenthsAndConvertMicrosecondsToMS(
+export function roundFloatAndConvertMicrosecondsToMS(
   ms: string | number
 ): number {
   ms = typeof ms === 'string' ? parseInt(ms, 10) : ms;
   ms = Math.floor(ms * 100) / 100000;
-  return Math.round(ms * 10) / 10;
+  return Math.round(ms);
 }
 
 export function fillArray(arrLngth: number, incr = 1, strt = 0): number[] {

--- a/packages/stats/test/stats.test.ts
+++ b/packages/stats/test/stats.test.ts
@@ -1,9 +1,11 @@
 import { Stats } from '../src/stats';
 import { expect } from 'chai';
 import { REGRESSION_RESULTS, HIGH_VARIANCE_RESULTS } from "./fixtures";
+import {roundTenthsAndConvertMicrosecondsToMS} from "../src/utils";
 
 const stats = new Stats({ control: REGRESSION_RESULTS.control, experiment: REGRESSION_RESULTS.experiment, name: 'stats-regression-test' });
-const statsHighVariance = new Stats({ control: HIGH_VARIANCE_RESULTS.control, experiment: HIGH_VARIANCE_RESULTS.experiment, name: 'stats-high-variance-test' });
+// high variance with unit converter to MS
+const statsHighVarianceMS = new Stats({ control: HIGH_VARIANCE_RESULTS.control, experiment: HIGH_VARIANCE_RESULTS.experiment, name: 'stats-high-variance-test' }, roundTenthsAndConvertMicrosecondsToMS);
 
 // stats testing a regression experiment
 describe('stats', () => {
@@ -17,6 +19,12 @@ describe('stats', () => {
     expect(stats.controlSorted[24]).to.equal(54893);
     expect(stats.experimentSorted[0]).to.equal(1124565);
     expect(stats.experimentSorted[24]).to.equal(1138314);
+
+    // MS
+    expect(statsHighVarianceMS.controlSorted[0]).to.equal(2241);
+    expect(statsHighVarianceMS.controlSorted[10]).to.equal(2374);
+    expect(statsHighVarianceMS.experimentSorted[0]).to.equal(2241);
+    expect(statsHighVarianceMS.experimentSorted[10]).to.equal(2364);
   });
 
   // samples NOT sorted
@@ -25,6 +33,11 @@ describe('stats', () => {
     expect(stats.control[24]).to.equal(54893);
     expect(stats.experiment[0]).to.equal(1124565);
     expect(stats.experiment[24]).to.equal(1138314);
+
+    // MS
+    expect(statsHighVarianceMS.control[0]).to.equal(2241);
+    expect(statsHighVarianceMS.control[24]).to.equal(2517);
+    expect(statsHighVarianceMS.experiment[0]).to.equal(2241);
   });
 
   // results should show strong evidence to reject H0 for H1
@@ -37,6 +50,12 @@ describe('stats', () => {
     // 0.000000001416
     expect(stats.confidenceInterval.pValue).to.equal(1.416e-9);
     expect(stats.confidenceInterval.U).to.equal(625);
+
+    // MS
+    expect(statsHighVarianceMS.confidenceInterval.min).to.equal(-95);
+    expect(statsHighVarianceMS.confidenceInterval.max).to.equal(84);
+    expect(statsHighVarianceMS.confidenceInterval.median).to.equal(-2);
+    expect(statsHighVarianceMS.confidenceInterval.pValue).to.equal(0.967);
   });
 
   it(`sevenFigureSummary()`, () => {
@@ -54,6 +73,10 @@ describe('stats', () => {
     expect(experimentQuantiles.max).to.equal(1138314);
     expect(experimentQuantiles[10]).to.equal(1126240);
     expect(experimentQuantiles[90]).to.equal(1135450);
+
+    // MS
+    expect(statsHighVarianceMS.sevenFigureSummary.control.min).to.equal(2241);
+    expect(statsHighVarianceMS.sevenFigureSummary.experiment.max).to.equal(5284);
   });
 
   it(`getHodgesLehmann()`, () => {
@@ -167,7 +190,7 @@ describe('stats', () => {
     expect(stats.populationVariance.control).to.equal(2872116.01);
     expect(stats.populationVariance.experiment).to.equal(11279513.36);
     // high variance
-    expect(statsHighVariance.populationVariance.control).to.equal(82019760000);
-    expect(statsHighVariance.populationVariance.experiment).to.equal(207342043600);
+    expect(statsHighVarianceMS.populationVariance.control).to.equal(82019760);
+    expect(statsHighVarianceMS.populationVariance.experiment).to.equal(207342043.6);
   });
 });

--- a/packages/stats/test/stats.test.ts
+++ b/packages/stats/test/stats.test.ts
@@ -1,11 +1,11 @@
 import { Stats } from '../src/stats';
 import { expect } from 'chai';
 import { REGRESSION_RESULTS, HIGH_VARIANCE_RESULTS } from "./fixtures";
-import {roundTenthsAndConvertMicrosecondsToMS} from "../src/utils";
+import { roundFloatAndConvertMicrosecondsToMS } from "../src/utils";
 
 const stats = new Stats({ control: REGRESSION_RESULTS.control, experiment: REGRESSION_RESULTS.experiment, name: 'stats-regression-test' });
 // high variance with unit converter to MS
-const statsHighVarianceMS = new Stats({ control: HIGH_VARIANCE_RESULTS.control, experiment: HIGH_VARIANCE_RESULTS.experiment, name: 'stats-high-variance-test' }, roundTenthsAndConvertMicrosecondsToMS);
+const statsHighVarianceMS = new Stats({ control: HIGH_VARIANCE_RESULTS.control, experiment: HIGH_VARIANCE_RESULTS.experiment, name: 'stats-high-variance-test' }, roundFloatAndConvertMicrosecondsToMS);
 
 // stats testing a regression experiment
 describe('stats', () => {
@@ -191,6 +191,6 @@ describe('stats', () => {
     expect(stats.populationVariance.experiment).to.equal(11279513.36);
     // high variance
     expect(statsHighVarianceMS.populationVariance.control).to.equal(82019760);
-    expect(statsHighVarianceMS.populationVariance.experiment).to.equal(207342043.6);
+    expect(statsHighVarianceMS.populationVariance.experiment).to.equal(207342044);
   });
 });


### PR DESCRIPTION
This PR includes the functionality to pass a unit conversion function during instantiation of the Stats class. Critically this conversion happens after statistical calculations as we need to guarantee ties are correctly handled with the raw data.