### PR TITLE
feat(cli): expose pvalue and evidence in reports

### DIFF
--- a/packages/cli/src/commands/compare/report.ts
+++ b/packages/cli/src/commands/compare/report.ts
@@ -40,6 +40,9 @@ Handlebars.registerHelper("toCamel", (val) => {
 Handlebars.registerHelper("isFaster", (analysis) => {
   return analysis.hlDiff > 0;
 });
+Handlebars.registerHelper("getQuality", (pVal, threshold) => {
+  return pVal < threshold;
+});
 Handlebars.registerHelper("abs", (num) => {
   return Math.abs(num);
 });

--- a/packages/cli/src/compare/compare-results.ts
+++ b/packages/cli/src/compare/compare-results.ts
@@ -105,8 +105,7 @@ export class CompareResults {
     this.phaseResultsFormatted.forEach((phaseData) => {
       const { phase, hlDiff, isSignificant, ciMin, ciMax } = phaseData;
       let msg = `${chalk.bold(phase)} phase `;
-      // buffer is sig on the estimator at 5 ms
-      const estimatorISig = Math.abs(hlDiff) >= 5 ? true : false;
+      const estimatorISig = Math.abs(hlDiff) >= 1 ? true : false;
       // isSignificant comes from the confidence interval range and pValue NOT estimator
       if (isSignificant && estimatorISig) {
         let coloredDiff;

--- a/packages/cli/src/compare/compare-results.ts
+++ b/packages/cli/src/compare/compare-results.ts
@@ -107,7 +107,7 @@ export class CompareResults {
       let msg = `${chalk.bold(phase)} phase `;
       // buffer is sig on the estimator at 5 ms
       const estimatorISig = Math.abs(hlDiff) >= 5 ? true : false;
-      // isSignificant comes from the confidence interval range NOT estimator
+      // isSignificant comes from the confidence interval range and pValue NOT estimator
       if (isSignificant && estimatorISig) {
         let coloredDiff;
 

--- a/packages/cli/src/compare/generate-stats.ts
+++ b/packages/cli/src/compare/generate-stats.ts
@@ -62,6 +62,7 @@ export interface HTMLSectionRenderData {
   controlFormatedSamples: FormattedStatsSamples;
   experimentFormatedSamples: FormattedStatsSamples;
   frequency: Frequency;
+  pValue: number;
 }
 
 type ValuesByPhase = {
@@ -222,6 +223,7 @@ export class GenerateStats {
       sampleCount: stats.sampleCount.control,
       ciMin: stats.confidenceInterval.min,
       ciMax: stats.confidenceInterval.max,
+      pValue: stats.confidenceInterval.pValue,
       hlDiff: stats.estimator,
       servers: undefined,
       frequency,

--- a/packages/cli/src/compare/tb-table.ts
+++ b/packages/cli/src/compare/tb-table.ts
@@ -153,6 +153,10 @@ export default class TBTable {
         ],
         [],
         [{ content: "Is Significant:" }, { content: `${statSig}` }],
+        [
+          { content: "P-Value:" },
+          { content: `${stat.confidenceInterval.pValue}` },
+        ],
         [],
         ["Control Sparkline", { content: `${stat.sparkLine.control}` }],
         [

--- a/packages/cli/src/static/phase-detail-partial.hbs
+++ b/packages/cli/src/static/phase-detail-partial.hbs
@@ -1,29 +1,33 @@
-<div class="avoid-page-break"> 
+<div class="avoid-page-break">
   <div class="row">
     <div class="col">
-      <h2>{{analysisForPhase.phase}}
+      <h2 class="phase">{{analysisForPhase.phase}}
         <small class="h5">
           {{#if analysisForPhase.isSignificant}}
-          {{#if (isFaster analysisForPhase)}}
-          <span class="text-success font-weight-bolder">({{abs analysisForPhase.hlDiff}} ms faster)</span>
+            {{#if (isFaster analysisForPhase)}}
+              <span class="text-success font-weight-bolder">({{abs analysisForPhase.hlDiff}} ms faster)</span>
+            {{else}}
+              <span class="text-danger font-weight-bolder">({{abs analysisForPhase.hlDiff}} ms slower)</span>
+            {{/if}}
           {{else}}
-          <span class="text-danger font-weight-bolder">({{abs analysisForPhase.hlDiff}} ms slower)</span>
-          {{/if}}
-          {{else}}
-          <span class="text-muted">(No Difference)</span>
+            <span class="text-muted">(No/Borderline Difference)</span>
           {{/if}}
         </small>
       </h2>
       <p>
-        A statistical analysis test was used <i>
-          <small>(<a href="https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test" target="_blank">Wilcoxon Rank-Sum
-              Test</a>)
-          </small>
-        </i> to determine that
+        Based on the P-value of this benchmark the evidence for a metric shift is {{#if (getQuality analysisForPhase.pValue 0.1)}}
+            {{#if (getQuality analysisForPhase.pValue 0.05)}}
+              <strong>very strong.</strong>
+            {{else}}
+              <strong>strong.</strong>
+            {{/if}}
+          {{else}}
+              <strong>weak.</strong>
+          {{/if}} TracerBench has determined the
         {{#if analysisForPhase.isSignificant}}
-        the results are significant meaning they are worth looking at.
+        results are <strong>significant</strong> meaning they are worth looking at.
         {{else}}
-        results are not significant.
+        results are <strong>not significant</strong>.
         {{/if}}
         {{#if analysisForPhase.isSignificant}}
         A statistics estimator <i>

--- a/packages/stats/src/stats.ts
+++ b/packages/stats/src/stats.ts
@@ -295,12 +295,14 @@ export class Stats {
     confidenceLevel: 0.8 | 0.85 | 0.9 | 0.95 | 0.99 | 0.995 | 0.999 = 0.95
   ): IConfidenceInterval {
     const ci = confidenceInterval(control, experiment, confidenceLevel);
-    const isSig =
+    const isCISig =
       (ci.lower < 0 && 0 < ci.upper) ||
       (ci.lower > 0 && 0 > ci.upper) ||
       (ci.lower === 0 && ci.upper === 0)
         ? false
         : true;
+    // ci sign must match on lower and upper bounds and pValue < 5%
+    const isSig = isCISig && ci.pValue < 0.05;
     return {
       min: Math.round(Math.ceil(ci.lower * 100) / 100),
       max: Math.round(Math.ceil(ci.upper * 100) / 100),


### PR DESCRIPTION
This PR provides the following functionality:
- expose pvalue evidence in pdf/html reports (very strong, strong or weak)
- expose pvalue in stdout report
- isSig includes p-val < 5%

Additionally adds the following language to the pdf/html reports:

```
Based on the P-value of this benchmark the evidence for a metric shift is very strong. TracerBench has
determined the results are significant meaning they are worth looking at. A statistics estimator 
(Hodges–Lehmann estimator) was used to determine "Experiment" is slower by 1011 ms. TracerBench 
is 95% confident "Experiment" is slower between 1008 ms to 1014 ms based on 10 samples 
using a (confidence interval).
```

```
ember (No/Borderline Difference)

Based on the P-value of this benchmark the evidence for a metric shift is weak. TracerBench has
determined the results are not significant.
```