### PR TITLE
feat(core): expose utility APIs for upstream to create custom measure…

### DIFF
--- a/packages/cli/src/command-config/index.ts
+++ b/packages/cli/src/command-config/index.ts
@@ -1,6 +1,13 @@
 import TBBaseCommand, { flags } from "./tb-base";
 
-export { ITBConfig, IHARServer, RegressionThresholdStat } from "./tb-config";
+export {
+  ITBConfig,
+  IHARServer,
+  RegressionThresholdStat,
+  IBenchmarkEnvironmentOverride,
+  CONTROL_ENV_OVERRIDE_ATTR,
+  EXPERIMENT_ENV_OVERRIDE_ATTR,
+} from "./tb-config";
 export {
   fidelityLookup,
   PerformanceTimingMark,

--- a/packages/cli/src/helpers/index.ts
+++ b/packages/cli/src/helpers/index.ts
@@ -2,9 +2,11 @@ import deviceSettings, {
   EmulateDeviceSetting,
   getEmulateDeviceSettingForKeyAndOrientation,
 } from "./device-settings";
+import { parseMarkers } from "./utils";
 
 export {
   deviceSettings,
   EmulateDeviceSetting,
   getEmulateDeviceSettingForKeyAndOrientation,
 };
+export { parseMarkers };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,17 @@ import RecordHAR from "./commands/record-har";
 import RecordHARAuth from "./commands/record-har/auth";
 
 export { run } from "@oclif/command";
-export { IHARServer, ITBConfig, PerformanceTimingMark } from "./command-config";
+export {
+  getConfig,
+  IHARServer,
+  ITBConfig,
+  PerformanceTimingMark,
+  TBBaseCommand,
+  IBenchmarkEnvironmentOverride,
+  CONTROL_ENV_OVERRIDE_ATTR,
+  EXPERIMENT_ENV_OVERRIDE_ATTR,
+  defaultFlagArgs,
+} from "./command-config";
 export * from "./helpers";
 export * from "./compare";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,14 @@ export type {
   PhaseSample
 } from './metrics/extract-navigation-sample';
 export type { PageSetupOptions } from './util/setup-page';
+export { default as setupPage } from './util/setup-page';
+export { default as injectMarkObserver } from './util/inject-mark-observer';
+export { default as navigate } from './util/navigate';
+export type { UsingTracingCallback } from './util/run-trace';
+export { default as runTrace } from './util/run-trace';
+export { default as gc } from './util/gc';
 export { default as run } from './run';
+
 export type {
   Benchmark,
   BenchmarkSampler,


### PR DESCRIPTION
I want to build new measurement command (idle CPU) using the utility API from the core and cli package. I have exposed some public utility functions for downstream to consume.