### PR TITLE
fixes empty cookie error

### DIFF
--- a/packages/cli/src/commands/record-har/index.ts
+++ b/packages/cli/src/commands/record-har/index.ts
@@ -74,7 +74,16 @@ export default class RecordHAR extends TBBaseCommand {
     if (cookiespath.length) {
       // grab the auth cookies
       const resolvedPath = resolve(cookiespath);
-      cookies = await readJson(resolvedPath);
+      const rawCookies:
+        | Protocol.Network.CookieParam[]
+        | { cookies: Protocol.Network.CookieParam[] } = await readJson(
+        resolvedPath
+      );
+      if (rawCookies && "cookies" in rawCookies) {
+        cookies = rawCookies.cookies as Protocol.Network.CookieParam[];
+      } else {
+        cookies = rawCookies as Protocol.Network.CookieParam[];
+      }
       if (!Array.isArray(cookies)) {
         throw `Incorrect cookie file format (${resolvedPath}), should be [ {name: "foo", value: "boo" } ]`;
       }


### PR DESCRIPTION
fixes:

 Error: Error: ProtocolError: At least one of the url or domain needs to be
     specified. CookieParam format invalid: https://chromedevtools.github.io/d
    evtools-protocol/tot/Network#type-CookieParam.


for default cookie fallback (if no file provided)

https://github.com/TracerBench/tracerbench/issues/338#issuecomment-870559516