### PR TITLE
fix: should use dynamic confidence level to calculate significance

### DIFF
--- a/packages/stats/src/stats.ts
+++ b/packages/stats/src/stats.ts
@@ -313,8 +313,9 @@ export class Stats {
       (ci.min === 0 && ci.max === 0)
         ? false
         : true;
+    const sigLevel: number = 1 - confidenceLevel;
     // ci sign must match on lower and upper bounds and pValue < 5%
-    const isSig = isCISig && ci.pValue < 0.05;
+    const isSig = isCISig && ci.pValue < sigLevel;
 
     return {
       min: Math.round(Math.ceil(ci.min * 100) / 100),

--- a/packages/stats/test/stats.test.ts
+++ b/packages/stats/test/stats.test.ts
@@ -31,6 +31,15 @@ const statsMS = new Stats(
   roundFloatAndConvertMicrosecondsToMS
 );
 
+const statsHighConf = new Stats(
+  {
+    control: REGRESSION_RESULTS.control,
+    experiment: REGRESSION_RESULTS.experiment,
+    name: 'stats-regression-test',
+    confidenceLevel: 0.99
+  },
+  roundFloatAndConvertMicrosecondsToMS
+);
 // stats testing a regression experiment
 describe('stats', () => {
   it(`name()`, () => {
@@ -84,6 +93,18 @@ describe('stats', () => {
       -2083.26
     );
     expect(statsMS.confidenceInterval.asPercent.percentMax).to.equal(-2081.14);
+
+    //confidence level at 0.99
+    // MS
+    expect(statsHighConf.confidenceInterval.min).to.equal(-1082);
+    expect(statsHighConf.confidenceInterval.max).to.equal(-1078);
+    expect(statsHighConf.confidenceInterval.median).to.equal(-1080);
+    expect(statsHighConf.confidenceInterval.pValue).to.equal(1.416e-9);
+    expect(statsHighConf.confidenceInterval.asPercent.percentMin).to.equal(-2087.14);
+    expect(statsHighConf.confidenceInterval.asPercent.percentMedian).to.equal(
+      -2083.26
+    );
+    expect(statsHighConf.confidenceInterval.asPercent.percentMax).to.equal(-2079.95);
 
     // HIGH VARIANCE MS
     expect(statsHighVarianceMS.confidenceInterval.min).to.equal(-95);


### PR DESCRIPTION
The significance level should be dynamically derived from the confidence level users configure.