### PR TITLE
feat: export APIs for rich report generation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "@oclif/test": "^1.2.8",
     "@types/chai": "^4.2.17",
     "@types/fs-extra": "^9.0.11",
-    "@types/html-minifier-terser": "^5.1.1",
+    "@types/html-minifier-terser": "^6.1.0",
     "@types/json-query": "^2.2.0",
     "@types/json5": "^2.2.0",
     "@types/listr": "^0.14.3",

--- a/packages/cli/src/compare/index.ts
+++ b/packages/cli/src/compare/index.ts
@@ -1,3 +1,4 @@
+import printToPDF from "./print-to-pdf";
 export {
   ITracerBenchTraceResult,
   GenerateStats,
@@ -5,3 +6,4 @@ export {
   ParsedTitleConfigs,
 } from "./generate-stats";
 export { ICompareJSONResults } from "./compare-results";
+export { printToPDF };

--- a/packages/cli/src/helpers/index.ts
+++ b/packages/cli/src/helpers/index.ts
@@ -2,11 +2,11 @@ import deviceSettings, {
   EmulateDeviceSetting,
   getEmulateDeviceSettingForKeyAndOrientation,
 } from "./device-settings";
-import { parseMarkers } from "./utils";
+import { parseMarkers, md5sum } from "./utils";
 
 export {
   deviceSettings,
   EmulateDeviceSetting,
   getEmulateDeviceSettingForKeyAndOrientation,
 };
-export { parseMarkers };
+export { parseMarkers, md5sum };

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -5,7 +5,8 @@ import {
   IOutliers,
   ISevenFigureSummary,
   IStatsOptions,
-  Stats
+  Stats,
+  Bucket
 } from './stats';
 import {
   convertMicrosecondsToMS,
@@ -17,6 +18,7 @@ import { getWilcoxonRankSumTest } from './wilcoxon-rank-sum';
 import { getWilcoxonSignedRankTest } from './wilcoxon-signed-rank';
 
 export {
+  Bucket,
   cartesianProduct,
   confidenceInterval,
   Stats,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,10 +1929,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/html-minifier-terser@^5.1.1":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
-  integrity sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==
+"@types/html-minifier-terser@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
+  integrity sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==
 
 "@types/json-query@^2.2.0":
   version "2.2.3"


### PR DESCRIPTION
1. Expose utility APIs for consumer library to create customized HTML and PDF reports. 
2. Upgrade to 6.1.0 type definition for html-minifier-terser. 

Validated all tests passed on Mac and Linux.